### PR TITLE
Updated Modal so it will only pop-up on first three votes

### DIFF
--- a/src/components/pages/MatchUp/RenderMatchUp.js
+++ b/src/components/pages/MatchUp/RenderMatchUp.js
@@ -12,8 +12,11 @@ const RenderMatchUp = props => {
   const { push } = useHistory();
   const [faceoffs, setFaceoffs] = useState([]);
   const [modalVisible, setModalVisible] = useState(true);
+
+  console.log('props.canVote', props);
+
   useEffect(() => {
-    if (!props.canVote) {
+    if (props.child.VotesRemaining <= 7) {
       setModalVisible(false);
     }
     setFaceoffs(props.faceoffs);
@@ -34,6 +37,7 @@ const RenderMatchUp = props => {
         title="The Matchup"
         versus={true}
         pointsToWin={true}
+        votesRemaining={true}
       />
       <QuestionCircleOutlined
         className="question-icon"


### PR DESCRIPTION
# Description

Fixes #


In this pull request I change the code so the Modal with information about having to vote 3 times, but being able to vote a maximum of ten times, only appears after the first three votes. This is only used in the voting section of the match-up. The first 3 votes unlock your opponents submissions. 

Changes in RenderMatchUp.JS useEffect.

This is a fix for [FT 3] "As a kid user, I want to be able to keep voting after the 3 main votes."

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)


## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested

- [ ] Yes
- [ ] No
- [ ] Not necessary

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
