### PR TITLE
Disables the Submit button until a kid votes on a faceoff.

### DIFF
--- a/src/components/common/VotingForm.js
+++ b/src/components/common/VotingForm.js
@@ -10,6 +10,7 @@ const VotingForm = props => {
   const { authState } = useOktaAuth();
   const { subEmojis1, subEmojis2 } = props.subEmojis;
   const [value, setValue] = useState();
+  const [buttonDisabled, setButtonDisabled] = useState(true);
 
   const onChange = e => {
     setValue(e.target.value);
@@ -41,8 +42,13 @@ const VotingForm = props => {
     console.log('Failed:', errorInfo);
   };
 
+  const onValuesChange = () => {
+    setButtonDisabled(false);
+  };
+
   return (
     <Form
+      onValuesChange={onValuesChange}
       name="basic"
       initialValues={{ remember: true }}
       onFinish={onFinish}
@@ -61,7 +67,11 @@ const VotingForm = props => {
         </Radio.Group>
       </Form.Item>
       <Form.Item>
-        <Button className="votingSubmit-button" htmlType="submit">
+        <Button
+          className="votingSubmit-button"
+          htmlType="submit"
+          disabled={buttonDisabled}
+        >
           Submit
         </Button>
       </Form.Item>


### PR DESCRIPTION
# Description

Disables the Submit button in the Voting Form until a kid user has voted on a submission in the faceoff.

This prevents a bug where the user was able to hit submit without voting which resulted in a null submission. This in turn would break the ability for subsequent votes to be correctly counted in the backend. It would appear from the front end as though the kid user was voting, but the database never saved any further votes.

This is a fix for [FT 3] "As a kid user, I want to be able to keep voting after the 3 main votes."

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, but not tested (may need new tests)

## Has This Been Tested

- [x] No

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
