### PR TITLE
Feature/kid user in match up

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -370,8 +370,6 @@ const getFaceoffsForVoting = async (authState, squadId) => {
       `/game/faceoffs/squads/?squadId=${squadId}`,
       getAuthHeader(authState)
     ).then(response => {
-      console.log('getFaceoffsForVoting', response.data);
-
       return response.data;
     });
   } catch (error) {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -342,10 +342,10 @@ const getChildSquad = async (authState, childId) => {
  * @param {number} squadId this will be received from 'getChildSquad' api call
  * @returns {Array} array of 4 objects (one for each child) containing information about their submissions
  */
-const getFaceoffsForMatchup = async (authState, squadId, childId = null) => {
+const getFaceoffsForMatchup = async (authState, squadId, childId) => {
   try {
     return apiAuthGet(
-      `/game/faceoffs?squadId=${squadId}&childId=${childId}`,
+      `/game/faceoffs/squads?squadId=${squadId}&childId=${childId}`,
       getAuthHeader(authState)
     ).then(response => {
       return response.data;
@@ -370,6 +370,8 @@ const getFaceoffsForVoting = async (authState, squadId) => {
       `/game/faceoffs/squads/?squadId=${squadId}`,
       getAuthHeader(authState)
     ).then(response => {
+      console.log('getFaceoffsForVoting', response.data);
+
       return response.data;
     });
   } catch (error) {

--- a/src/components/pages/MatchUp/FaceoffContent.js
+++ b/src/components/pages/MatchUp/FaceoffContent.js
@@ -28,9 +28,7 @@ const FaceoffContent = props => {
           type={props.content.Type}
           feedback={props.content.Emojis1}
           votesNeededToUnlock={props.votesNeededToUnlock}
-          votesRemaining={props.votesRemaining}
-          dayNeededToUnlock={props.dayNeededToUnlock}
-          hourNeededToUnlock={props.hourNeededToUnlock}
+          mySquad="mySquad"
         />
       )}
       <img src={matchup_bolt} alt="lightning bolt" onClick={revealWinner} />
@@ -76,6 +74,18 @@ const FaceoffSubDisplay = ({ sub, type, feedback, ...props }) => {
   };
 
   useEffect(() => {
+    if (props.mySquad) {
+      setLocked(false);
+    }
+
+    if (
+      props.votesNeededToUnlock &&
+      props.votesNeededToUnlock >= props.votesRemaining &&
+      !props.dayNeededToUnlock
+    ) {
+      setLocked(false);
+    }
+
     if (
       props.votesNeededToUnlock &&
       props.votesNeededToUnlock >= props.votesRemaining &&

--- a/src/components/pages/MatchUp/MatchUpContainer.js
+++ b/src/components/pages/MatchUp/MatchUpContainer.js
@@ -13,12 +13,9 @@ import {
 } from '../../../api/index';
 
 function MatchUpContainer({ LoadingComponent, ...props }) {
-  //ERRLOG: child id is not being passed into the params properly, cannot find child with ID of null
-
   const { authState, authService } = useOktaAuth();
   const [userInfo, setUserInfo] = useState(null);
   const [canVote, setCanVote] = useState(true);
-  const [updateFaceoffs, setUpdateFaceoffs] = useState([]);
   // eslint-disable-next-line
   const [memoAuthService] = useMemo(() => [authService], []);
 
@@ -31,7 +28,6 @@ function MatchUpContainer({ LoadingComponent, ...props }) {
       if (props.child.Ballots.length > 0 && props.child.VotesRemaining > 0) {
         for (let ballot of props.child.Ballots) {
           getFaceoffsForVoting(authState, ballot[1]).then(faceoffs => {
-            setUpdateFaceoffs(faceoffs);
             if (props.votes.length === 0) {
               for (let faceoff of faceoffs) {
                 if (faceoff.ID === ballot[0]) {
@@ -96,7 +92,6 @@ function MatchUpContainer({ LoadingComponent, ...props }) {
           authService={authService}
           canVote={canVote}
           votesRemaining={props.child.VotesRemaining}
-          faceoffs={updateFaceoffs}
         />
       )}
     </>

--- a/src/components/pages/MatchUp/RenderMatchUp.js
+++ b/src/components/pages/MatchUp/RenderMatchUp.js
@@ -76,8 +76,6 @@ const RenderMatchUp = props => {
                 content={faceoffs[1]}
                 votesRemaining={props.votesRemaining}
                 votesNeededToUnlock={7}
-                dayNeededToUnlock={4}
-                hourNeededToUnlock={6}
               />
             )}
           </Col>
@@ -90,8 +88,6 @@ const RenderMatchUp = props => {
                 content={faceoffs[2]}
                 votesRemaining={props.votesRemaining}
                 votesNeededToUnlock={8}
-                dayNeededToUnlock={4}
-                hourNeededToUnlock={6}
               />
             )}
           </Col>
@@ -102,8 +98,6 @@ const RenderMatchUp = props => {
                 content={faceoffs[3]}
                 votesRemaining={props.votesRemaining}
                 votesNeededToUnlock={9}
-                dayNeededToUnlock={4}
-                hourNeededToUnlock={6}
               />
             )}
           </Col>


### PR DESCRIPTION
# Description

The kid user whose account you are in was not being rendered in the Match Up. This was because the Voting Faceoffs were being passed in rather than the Match Up faceoffs.
Locks were also based on the day of the week when only the final lock needs to consider the day.
Locks exist on your own squad's submissions when they only need to exist on the opposing squad's submissions

- To fix rendering the correct users we removed where faceoffs was being overwritten to voting faceoffs in MatchUpContainer.js
- To fix the issue where the correct faceoffs for Match ups was not being passed in we changed the URL for the get request in index.js to include /squads so that it calls the right endpoint.

- To fix locks we removed unnecessary props that were being passed including hard coding the day needed to unlock.
- We also updated the logic to allow your own squad's submissions to always be unlocked

This is a fix for [FT 3] As a kid user, I want to be able to keep voting after the 3 main votes

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, but not tested (may need new tests)

## Has This Been Tested

- [x] No

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
