### PR TITLE
Feat/sm/dev mode monday state

### DIFF
--- a/src/components/pages/AdminDashboard/DevTools/DayComponent.js
+++ b/src/components/pages/AdminDashboard/DevTools/DayComponent.js
@@ -1,14 +1,20 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { Layout, Button } from 'antd';
+import { connect } from 'react-redux';
+import { devMode } from '../../../../state/actions/index';
 
 const { Content } = Layout;
 
-const DayComponent = ({ day }) => {
+const DayComponent = ({ day, devMode, setDevMode }) => {
   const { push } = useHistory();
 
   const handleSim = () => {
     push(`${day.gameStageUrl}`);
+  };
+
+  const handleDevMode = () => {
+    setDevMode(!devMode.isDevModeActive);
   };
 
   return (
@@ -18,6 +24,9 @@ const DayComponent = ({ day }) => {
       <h4>{day.stage}</h4>
       <Content>
         <p>{day.content}</p>
+        <button onClick={handleDevMode}>
+          {devMode.isDevModeActive ? 'Deactivate' : 'Activate'} developer mode
+        </button>
       </Content>
       <Button
         style={{ width: '45%' }}
@@ -30,4 +39,9 @@ const DayComponent = ({ day }) => {
   );
 };
 
-export default DayComponent;
+export default connect(
+  state => ({
+    devMode: state.devMode,
+  }),
+  { setDevMode: devMode.setDevMode }
+)(DayComponent);

--- a/src/components/pages/MissionControl/RenderMissionControl.js
+++ b/src/components/pages/MissionControl/RenderMissionControl.js
@@ -24,13 +24,21 @@ const RenderMissionControl = props => {
   const { push } = useHistory();
   const { authState } = useOktaAuth();
 
+  /**
+   * On initial render, checks to see if tasks in state (hasRead, hasWritten, etc)
+   * if not (and if dev mode not active), calls getChildTasks -> getOrInitSubmission on backend
+   *    (returns a childs task data)
+   *    calls getStory regardless of if devMode is active or not.
+   */
   useEffect(() => {
     if (props.tasks.id === null) {
-      getChildTasks(authState, props.child.id, props.child.cohortId).then(
-        res => {
-          props.setTasks(res);
-        }
-      );
+      if (props.devMode.isDevModeActive === false) {
+        getChildTasks(authState, props.child.id, props.child.cohortId).then(
+          res => {
+            props.setTasks(res);
+          }
+        );
+      }
 
       getStory(authState, props.child.cohortId).then(res => {
         props.setSubmissionInformation(res);
@@ -148,6 +156,7 @@ export default connect(
     hasRead: state.tasks.hasRead,
     hasWritten: state.tasks.hasWritten,
     hasDrawn: state.tasks.hasDrawn,
+    devMode: state.devMode,
   }),
   {
     setTasks: tasks.setTasks,

--- a/src/state/actions/devModeActions.js
+++ b/src/state/actions/devModeActions.js
@@ -1,0 +1,5 @@
+export const SET_DEV_MODE = 'SET_DEV_MODE';
+
+export const setDevMode = boolean => {
+  return { type: SET_DEV_MODE, payload: boolean };
+};

--- a/src/state/actions/index.js
+++ b/src/state/actions/index.js
@@ -6,5 +6,6 @@ import * as team from './teamActions';
 import * as faceoffs from './faceoffsActions';
 import * as votes from './votesActions';
 import * as date from './dateAction';
+import * as devMode from './devModeActions';
 
-export { global, child, parent, tasks, team, faceoffs, votes, date };
+export { global, child, parent, tasks, team, faceoffs, votes, date, devMode };

--- a/src/state/reducers/devModeReducer.js
+++ b/src/state/reducers/devModeReducer.js
@@ -19,6 +19,7 @@ export const reducer = (state = initialState, action) => {
     case SET_DEV_MODE:
       return {
         ...state,
+        isDevModeActive: action.payload,
       };
     default:
       return state;

--- a/src/state/reducers/devModeReducer.js
+++ b/src/state/reducers/devModeReducer.js
@@ -4,7 +4,7 @@ const initialState = {
   isDevModeActive: false,
 };
 
-export const devModeReducer = (state = initialState, action) => {
+export const reducer = (state = initialState, action) => {
   switch (action.type) {
     case SET_DEV_MODE:
       return {

--- a/src/state/reducers/devModeReducer.js
+++ b/src/state/reducers/devModeReducer.js
@@ -1,0 +1,16 @@
+const SET_DEV_MODE = 'SET_DEV_MODE';
+
+const initialState = {
+  isDevModeActive: false,
+};
+
+export const devModeReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case SET_DEV_MODE:
+      return {
+        ...state,
+      };
+    default:
+      return state;
+  }
+};

--- a/src/state/reducers/devModeReducer.js
+++ b/src/state/reducers/devModeReducer.js
@@ -4,6 +4,16 @@ const initialState = {
   isDevModeActive: false,
 };
 
+/**
+ * devMode state
+ * It is intended that when isDevModeActive: true, relevant API calls will transition
+ *      to hit devMode database instead of primary database,
+ *      this allows devMode to be separate from the real database (usable in production)
+ *
+ * It is also important to ensure that when dev mode turns off the MODIFIED state returns to normal
+ *      at the very least, it should be ensured that modified states will correct themselves
+ *      this is important to look into in the future
+ */
 export const reducer = (state = initialState, action) => {
   switch (action.type) {
     case SET_DEV_MODE:

--- a/src/state/reducers/index.js
+++ b/src/state/reducers/index.js
@@ -11,6 +11,7 @@ import { reducer as team } from './teamReducers';
 import { reducer as faceoffs } from './faceoffsReducer';
 import { reducer as votes } from './votesReducer';
 import { reducer as date } from './dateReducer';
+import { reducer as devMode } from './devModeReducer';
 
 const persistConfig = {
   key: 'root',
@@ -26,6 +27,7 @@ const rootReducer = combineReducers({
   faceoffs,
   votes,
   date,
+  devMode,
 });
 
 export default persistReducer(persistConfig, rootReducer);


### PR DESCRIPTION
# Description

Fixes #

- What work was done?
- devModeReducer & actions were created for isDevModeActive.  isDevModeActive connected to DayComponent, so that users may toggle it on and off.
- Why was this work done?
- API queries that interact with the database should be converted to use the mock-database when a user is in developer mode.  This state allows us to use the boolean ```isDevModeActive ?``` when deciding API calls and other logic that should change based off of developer mode.
- What feature / user story is it for?
- "As a developer, I want to be able to pick a day of the week/game cycle to move the game into."
- Any relevant links or images / screenshots

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Change Status

- [x] Complete, but not tested (may need new tests)

## Has This Been Tested

- [x] No

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
