### PR TITLE
Fixed a discrepancy in the test suite initial state

### DIFF
--- a/src/__tests__/ChildReducer.test.js
+++ b/src/__tests__/ChildReducer.test.js
@@ -11,6 +11,12 @@ describe('childReducer test suite', () => {
     parentId: null,
     cohortId: null,
     memberId: null,
+    VotesRemaining: null,
+    totalPoints: null,
+    wins: null,
+    losses: null,
+    achievements: null,
+    Ballots: [],
   };
 
   it('should return the initial state with no actions passed in', () => {
@@ -41,19 +47,22 @@ describe('childReducer test suite', () => {
       gradeLevel: '3',
       parentId: 1,
       cohortId: 1,
-      memberId: null, 
+      memberId: null,
     });
   });
 
   it('should update the member id', () => {
-    const action = { type: child.SET_MEMBER_ID, payload: {
-      ...initialState, 
-      MemberID: 1
-    } };
+    const action = {
+      type: child.SET_MEMBER_ID,
+      payload: {
+        ...initialState,
+        MemberID: 1,
+      },
+    };
     const state = reducer(initialState, action);
     expect(state).toEqual({
-      ...initialState, 
-      memberId: 1
+      ...initialState,
+      memberId: 1,
     });
   });
 


### PR DESCRIPTION
# Description

Fixes #

- What work was done? Altered inital state in the test suite to match up with the initalState from the reducer.
- Why was this work done? To fix a false negative on a Jest test.
- What feature / user story is it for? Child reducer Test Suite should return initial state when clear users is called.
## Type of change

Please delete options that are not relevant.

- [✓] Bug fix (non-breaking change which fixes an issue)
## Change Status

- [✓] Complete, tested, ready to review and merge
- [✓] Complete, but not tested (may need new tests)
- [✓] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested

- [ ✓] Not necessary

## Checklist

- [✓] My code follows the style guidelines of this project
- [✓] I have performed a self-review of my own code
- [✓] My code has been reviewed by at least one peer
- [✓] I have commented my code, particularly in hard-to-understand areas
- [✓] I have made corresponding changes to the documentation
- [✓] My changes generate no new warnings
- [✓] I have added tests that prove my fix is effective or that my feature works
- [✓] New and existing unit tests pass locally with my changes
- [✓] There are no merge conflicts
