### PR TITLE
Parent-dash-support-single-page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11135,6 +11135,11 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
     },
+    "gsap": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.6.1.tgz",
+      "integrity": "sha512-hCkjk7UVbeEmlpFbiy7lIsh742bwVlMhdCnnQ1CvVOAdURyPX8hXjFZGh/0YzUyAcWPyJPE0/paMhSYtLhGlfA=="
+    },
     "gud": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint": "^6.6.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.20.6",
+    "gsap": "^3.6.1",
     "prettier": "^2.1.1",
     "react": "^16.13.1",
     "react-datepicker": "^3.4.1",

--- a/src/components/pages/SupportPage/ContactUsForm.js
+++ b/src/components/pages/SupportPage/ContactUsForm.js
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import emailjs from 'emailjs-com';
+
+function ContactUs({ success, visible, userInfo }) {
+  //This function takes care of sending the data captured in the
+  // form to a dedicated email address.
+  function sendEmail(e) {
+    e.preventDefault();
+    emailjs
+      .sendForm(
+        process.env.REACT_APP_SERVICE_ID,
+        process.env.REACT_APP_TEMPLATE_ID,
+        e.target,
+        process.env.REACT_APP_USER_ID
+      )
+      .then(
+        result => {
+          console.log(result.text);
+        },
+        error => {
+          console.log(error.text);
+        }
+      );
+    //reset the form values
+    e.target.reset();
+    //display the success message
+    success();
+    // close the modal
+    visible();
+  }
+
+  return (
+    <div>
+      <form className="Contact-Form-Container" onSubmit={sendEmail}>
+        <label>
+          <p>Name</p>
+        </label>
+        <input
+          type="text"
+          name="name"
+          className="contact-form-inputs"
+          defaultValue={userInfo.name}
+        />
+        <label>
+          <p>Email</p>
+        </label>
+        <input
+          type="email"
+          name="email"
+          className="contact-form-inputs"
+          defaultValue={userInfo.email}
+        />
+        <label>
+          <p>Subject</p>
+        </label>
+        <input type="text" name="subject" className="contact-form-inputs" />
+        <label>
+          <p>Message</p>
+        </label>
+        <textarea name="message" className="contact-form-message" />
+        <div className="contact-button-container">
+          <input
+            type="submit"
+            value="Send"
+            className="contact-form-submit-button"
+          />
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default ContactUs;

--- a/src/components/pages/SupportPage/FAQ.js
+++ b/src/components/pages/SupportPage/FAQ.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Collapse } from 'antd';
+import { CaretRightOutlined } from '@ant-design/icons';
+
+const { Panel } = Collapse;
+
+function FAQ(props) {
+  const text = `
+    A dog is a type of domesticated animal.
+    Known for its loyalty and faithfulness,
+    it can be found as a welcome guest in many households across the world.
+  `;
+
+  return (
+    <div className="FAQ-container">
+      <Collapse
+        bordered={false}
+        defaultActiveKey={['1']}
+        expandIcon={({ isActive }) => (
+          <CaretRightOutlined rotate={isActive ? 90 : 0} />
+        )}
+        className="site-collapse-custom-collapse"
+      >
+        <Panel
+          header="Question 1 goes here and this is just extra placeholder text?"
+          key="1"
+          className="site-collapse-custom-panel"
+        >
+          <p>Answer for 1 goes here and of course more placeholder text.</p>
+        </Panel>
+        <Panel
+          header="Question 2 goes here and will there be more placeholder text
+          this time?"
+          key="2"
+          className="site-collapse-custom-panel"
+        >
+          <p>
+            Answer for 2 goes here. Absolutely there will be more place- holder
+            text in this wireframe.
+          </p>
+        </Panel>
+        <Panel
+          header="Question 3 goes here but will the placeholder text ever stop?"
+          key="3"
+          className="site-collapse-custom-panel"
+        >
+          <p>
+            Answer for 3 goes here. Unfortunately, this is where the place-
+            holder text has to stop.
+          </p>
+        </Panel>
+      </Collapse>
+    </div>
+  );
+}
+
+export default FAQ;

--- a/src/components/pages/SupportPage/RenderSupportPage.js
+++ b/src/components/pages/SupportPage/RenderSupportPage.js
@@ -1,15 +1,113 @@
-import React from 'react';
-import { gsap } from 'gsap';
+import React, { useRef, useEffect, useState } from 'react';
+import { TweenMax, Power3 } from 'gsap';
+import ContactUsForm from './ContactUsForm';
+import { useSelector } from 'react-redux';
+import FAQ from './FAQ';
 
 function RenderSupportPage({ success }) {
+  //access the parents information in the reducer so we can pre-populate the form with their name & email.
+  const userInfo = useSelector(state => state.parent);
+
+  const [displayItem, setDisplayItem] = useState({ Form: false, Faq: false });
+  let FAQbutton = useRef(null);
+  let Contactbutton = useRef(null);
+  let Form = useRef(null);
+  const animate = input => {
+    TweenMax.to([FAQbutton, Contactbutton], 0.5, { css: { height: '10vh' } });
+    TweenMax.staggerTo([FAQbutton, Contactbutton], 1, {
+      x: 0,
+      y: 350,
+      ease: Power3.easeIn,
+    });
+    input == 'contact-button'
+      ? setDisplayItem({ Form: true, Faq: false })
+      : setDisplayItem({ Form: false, Faq: true });
+  };
+
   return (
-    <div className="container">
-      <button className="FAQ">
-        <h3>FAQ</h3>
-      </button>
-      <button className="contact">
-        <h3>Contact Us</h3>
-      </button>
+    <div className="support-container">
+      {displayItem.Form ? (
+        <div
+          className="Contact-Form-Container"
+          ref={el => {
+            Form = el;
+          }}
+        >
+          <ContactUsForm success={success} userInfo={userInfo} />
+          <div className="support-buttons-container">
+            <button
+              className="FAQ-button"
+              ref={el => {
+                FAQbutton = el;
+              }}
+              onClick={animate}
+            >
+              <h3>FAQ</h3>
+            </button>
+            <button
+              className="contact-button"
+              ref={el => {
+                Contactbutton = el;
+              }}
+              onClick={() => animate('contact-button')}
+            >
+              <h3>Contact Us</h3>
+            </button>
+          </div>
+        </div>
+      ) : displayItem.Faq ? (
+        <div
+          className="FAQ-Container"
+          ref={el => {
+            Form = el;
+          }}
+        >
+          <FAQ />
+          <div className="support-buttons-container">
+            <button
+              className="FAQ-button"
+              ref={el => {
+                FAQbutton = el;
+              }}
+              onClick={animate}
+            >
+              <h3>FAQ</h3>
+            </button>
+            <button
+              className="contact-button"
+              ref={el => {
+                Contactbutton = el;
+              }}
+              onClick={() => animate('contact-button')}
+            >
+              <h3>Contact Us</h3>
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="support-buttons-container">
+            <button
+              className="FAQ-button"
+              ref={el => {
+                FAQbutton = el;
+              }}
+              onClick={animate}
+            >
+              <h3>FAQ</h3>
+            </button>
+            <button
+              className="contact-button"
+              ref={el => {
+                Contactbutton = el;
+              }}
+              onClick={() => animate('contact-button')}
+            >
+              <h3>Contact Us</h3>
+            </button>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/pages/SupportPage/RenderSupportPage.js
+++ b/src/components/pages/SupportPage/RenderSupportPage.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { gsap } from 'gsap';
+
+function RenderSupportPage({ success }) {
+  return (
+    <div className="container">
+      <button className="FAQ">
+        <h3>FAQ</h3>
+      </button>
+      <button className="contact">
+        <h3>Contact Us</h3>
+      </button>
+    </div>
+  );
+}
+
+export default RenderSupportPage;

--- a/src/components/pages/SupportPage/SupportPageContainer.js
+++ b/src/components/pages/SupportPage/SupportPageContainer.js
@@ -1,38 +1,30 @@
-import React, { useState } from 'react';
+import React from 'react';
+import RenderSupportPage from './RenderSupportPage';
 import { Header } from '../../common';
-import { Modal } from 'antd';
+import { toast, ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.min.css';
 
 function SupportPageContainer(props) {
-  const [modalVisible, setModalVisible] = useState(false);
+  //this function takes care of the success message displayed on the screen
+  //when the user hits submit to send the form data to a dedicated email addy
 
+  const toastifySuccess = () => {
+    toast('Form sent!', {
+      position: 'bottom-right',
+      autoClose: 3000,
+      hideProgressBar: true,
+      closeOnClick: true,
+      pauseOnHover: true,
+      draggable: false,
+      className: 'submit-feedback success',
+      toastId: 'notifyToast',
+    });
+  };
   return (
     <>
       <Header title="Support" displayMenu={true} />
-
-      <Modal
-        className="Contact-modal"
-        visible={modalVisible}
-        keyboard={true}
-        width={'70%'}
-        onCancel={() => setModalVisible(false)}
-        zIndex={2000}
-        cancelButtonProps={{ disabled: true }}
-        //contact us via our social here
-        footer="Information on Socials"
-        closeIcon="X"
-      >
-        <p>Contact Us</p>
-        {/* <ContactForm /> */}
-      </Modal>
-
-      <div className="container">
-        <button className="FAQ">
-          <h3>FAQ</h3>
-        </button>
-        <button className="contact" onClick={() => setModalVisible(true)}>
-          <h3>Contact Us</h3>
-        </button>
-      </div>
+      <RenderSupportPage sucess={toastifySuccess} />
+      <ToastContainer />
     </>
   );
 }

--- a/src/styles/less/SupportPage.less
+++ b/src/styles/less/SupportPage.less
@@ -1,45 +1,118 @@
 @import '../less/variables.less';
 
-.container {
-    height: 40vh;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-    gap: 20px;
+.support-container {
+  height: 40vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
 }
-.FAQ {
-    width: 33%;
-    height: 20vh;
-    border-radius: 14px;
-    justify-content: center;
-    cursor: pointer;
-    background: @button-blue;
-    border: none;
-    color: @white-smoke;
-    font-size: 1rem;
-  }
-  .contact {
-    width: 33%;
-    height: 20vh;
-    border-radius: 14px;
-    justify-content: center;
-    cursor: pointer;
-    background: @burnt-sienna;
-    border: none;
-    color: @white-smoke;
-    font-size: 1rem;
-  }
-  h3 {
-    color: #ffffff;
-    text-shadow: -4px 0 black, 0 4px black, 4px 0 black, 0 -4px black;
-    text-align: center;
+.support-buttons-container {
+  z-index: 2;
+  height: 40vh;
+  width: 80vw;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 20%;
+}
+.FAQ-button {
+  width: 33%;
+  height: 20vh;
+  border-radius: 14px;
+  justify-content: center;
+  cursor: pointer;
+  background: @button-blue;
+  border: none;
+  color: @white-smoke;
+  font-size: 1rem;
+}
+.contact-button {
+  width: 33%;
+  height: 20vh;
+  border-radius: 14px;
+  justify-content: center;
+  cursor: pointer;
+  background: @burnt-sienna;
+  border: none;
+  color: @white-smoke;
+  font-size: 1rem;
+}
+h3 {
+  color: #ffffff;
+  text-shadow: -4px 0 black, 0 4px black, 4px 0 black, 0 -4px black;
+  text-align: center;
+  font-size: 3rem;
+  font-family: 'bangers';
+  font-weight: bold;
+  z-index: 1;
+  letter-spacing: 7px;
+  @media @mobile {
     font-size: 3rem;
-    font-family: 'bangers';
-    font-weight: bold;
-    z-index: 1;
-    letter-spacing: 7px;
-    @media @mobile {
-      font-size: 3rem;
-    }
   }
+}
+
+//Contact Form
+
+.Contact-Form-Container {
+  z-index: 0;
+  width: 50vw;
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+}
+
+.contact-form-inputs {
+  width: 60%;
+  margin-bottom: 15px;
+  letter-spacing: 5px;
+  font-weight: 600;
+  text-align: center;
+  border-radius: 4px;
+}
+
+.contact-form-message {
+  width: 60%;
+  height: 10vh;
+  font-weight: 300;
+  border-radius: 4px;
+}
+
+.contact-button-container {
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+  width: 100%;
+  padding: 20px;
+}
+
+.contact-form-submit-button {
+  width: 50%;
+  border-radius: 14px;
+  justify-content: center;
+  cursor: pointer;
+  background: @button-blue;
+  font-size: 1rem;
+  background: @white-smoke;
+  border: 3px solid @button-blue;
+  color: @button-blue;
+  box-shadow: 2px 1px 1px;
+  &:hover {
+    background: @button-blue;
+    color: @white-smoke;
+  }
+}
+
+//FAQ
+.FAQ-container {
+  z-index: 1;
+}
+.site-collapse-custom-collapse .site-collapse-custom-panel,
+.site-collapse-custom-collapse .site-collapse-custom-panel {
+  margin-bottom: 24px;
+  overflow: hidden;
+  background: #f7f7f7;
+  border: 0px;
+  border-radius: 2px;
+}


### PR DESCRIPTION
# Description
This is the second of three iterations on the support page of the parent dashboard. In this iteration both the FAQ and Contact us forms are displayed on the real estate of the support page. 

GSAP was added to the package.json to handle animations. 

Fixes #

- What work was done?
- added contact form and FAQ to support landing page
- Why was this work done?
- to allow the user to Access resources on FAQ and to contact the staff at Story Squad. 
- What feature / user story is it for?
- As a parent, I would like a clear dashboard that allows for support like a contact page.
- Any relevant links or images / screenshots

## Type of change

Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)


## Change Status

- [ ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested

- [ ] Yes
- [ ] No
- [ ] Not necessary

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
