### PR TITLE
Remove sensitive info

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,8 +1,10 @@
+# do not commit sensitive info in the repo
+
 REACT_APP_ENDPOINT=http://localhost:3000
-REACT_APP_CLIENT_ID=0oavsomz01GzuGikY4x6
+REACT_APP_CLIENT_ID=<okta client id>
 REACT_APP_OKTA_ISSUER_URI=https://auth.lambdalabs.dev/oauth2/default
 REACT_APP_API_URI=http://localhost:8000
-REACT_APP_DS_API	https://a-ds.storysquad.dev/	
-REACT_APP_DS_TOKEN	xD5w6CTfQSh6qs4xviIV6viQomie3ePjQQeDQjsr	
-REACT_APP_S3_KEY	AKIASVA5GJL5XYJ7V75C	
-REACT_APP_S3_SECRET_KEY	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
+REACT_APP_DS_API=https://a-ds.storysquad.dev/	
+REACT_APP_DS_TOKEN=<ds api key>
+REACT_APP_S3_KEY=<aws s3 key>
+REACT_APP_S3_SECRET_KEY=<aws secret key>


### PR DESCRIPTION
Sensitive data regarding okta and aws was committed to the .env.sample file. As discussed in the [Lambda Labs Docs](https://docs.labs.lambdaschool.com/home/#please-read-this-carefully) and is a serious security issue. 

The s3 bucket or aws account tied to the key will need to be deleted.