### PR TITLE
Remove Modal from parent dashboard when logging in

### DIFF
--- a/src/components/common/NewChildCard.js
+++ b/src/components/common/NewChildCard.js
@@ -4,7 +4,6 @@ import { PlusCircleFilled } from '@ant-design/icons';
 import { Card, Button, Layout } from 'antd';
 
 import { connect } from 'react-redux';
-
 import { getLeaderboard } from '../../api';
 import { useOktaAuth } from '@okta/okta-react/dist/OktaContext';
 

--- a/src/components/common/ParentLoadingComponent.js
+++ b/src/components/common/ParentLoadingComponent.js
@@ -2,7 +2,7 @@ import { SmileFilled } from '@ant-design/icons';
 import { Layout, Spin } from 'antd';
 import PropTypes from 'prop-types';
 import React from 'react';
-import ParentNavSider from '../common/ParentNavSider';
+
 
 function ParentLoadingComponent(props) {
   const { message } = props;

--- a/src/components/common/ParentLoadingComponent.js
+++ b/src/components/common/ParentLoadingComponent.js
@@ -9,7 +9,6 @@ function ParentLoadingComponent(props) {
 
   return (
     <div className="parent-loader">
-      <ParentNavSider key={null} />
       <Layout>
         <Spin
           indicator={<SmileFilled className="spinner" spin />}

--- a/src/components/pages/NewParentDashboard/RenderNewParentDashboard.js
+++ b/src/components/pages/NewParentDashboard/RenderNewParentDashboard.js
@@ -1,13 +1,29 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import { Layout, Card } from 'antd';
-import { PlusCircleFilled } from '@ant-design/icons';
+import React, {useEffect} from 'react';
+import { Layout} from 'antd';
+import { useOktaAuth } from '@okta/okta-react';
+import { getProfileData } from '../../../api';
 import ParentNavTopBar from '../../common/ParentNavTopBar';
 import NewProgressCharts from '../../common/NewProgressCharts';
 import NewChildCard from '../../common/NewChildCard';
 import AccountSettings from '../AccountSettings/AccountSettingsContainer';
+import { connect } from 'react-redux';
+import {setParent} from '../../../state/actions/parentActions';
+
+
 
 const RenderNewParentDashboard = props => {
+  const { authState } = useOktaAuth();
+  const { setParent } = props;
+
+  useEffect(() => {
+    getProfileData(authState).then(res => {
+      setParent({
+        ...res[0],
+        children: res.filter(user => user.type !== 'Parent'),
+      });
+    });
+  }, [setParent, authState]);
+
   return (
     <>
       <Layout className="parent-dashboard">
@@ -29,4 +45,4 @@ const RenderNewParentDashboard = props => {
   );
 };
 
-export default RenderNewParentDashboard;
+export default connect(null, {setParent:setParent})(RenderNewParentDashboard);

--- a/src/index.js
+++ b/src/index.js
@@ -37,8 +37,6 @@ import { LandingPage } from './components/pages/LandingPage';
 import { MissionControl } from './components/pages/MissionControl';
 import { Modal } from './components/pages/Modal';
 import { NotFoundPage } from './components/pages/NotFound';
-import { ParentDashboard } from './components/pages/ParentDashboard';
-
 import { ParentFaq } from './components/pages/ParentFaq';
 
 import { NewParentDashboard } from './components/pages/NewParentDashboard';
@@ -50,6 +48,7 @@ import { WritingSub } from './components/pages/WritingSub';
 import LoginCallbackLoader from './components/common/LoginCallbackLoader';
 import { Leaderboard } from './components/pages/Leaderboard';
 import FaceoffReveal from './components/pages/Animations/FaceoffReveal';
+
 
 // Gameification Components
 import { JoinTheSquad } from './components/pages/JoinTheSquad';
@@ -106,7 +105,7 @@ function App() {
         <SecureRoute
           path="/"
           exact
-          component={() => <Modal LoadingComponent={ChildLoadingComponent} />}
+          component={() => <NewParentDashboard LoadingComponent={ParentLoadingComponent} />}
         />
         <SecureRoute
           path="/child/story"
@@ -159,7 +158,6 @@ function App() {
           path="/parent/dashboard"
           exact
           component={() => (
-            // <ParentDashboard LoadingComponent={ParentLoadingComponent} /> This is the old Parent Dashboard
             <NewParentDashboard LoadingComponent={ParentLoadingComponent} />
           )}
         />


### PR DESCRIPTION
# Pull Request Template

## Description
Add a summary that address the following:
 - motivation/purpose for the feature
     -Making the parent dashboard look presentable
 - What were those changes
     -  Removed the pop up for selecting parents/child, to just directly go into the parent dashboard 
 - What issues were fixed 
      - Removed the modal so that the parent can go directly into their dashboard
 - Provide the link to the user story it is referencing in Trello board or other supporting document
      - As a parent, I would like to go directly into my dashboard to see my children's information

## Commits Checklist
- [x] commits have clear title names 
- [x] commit has descriptive message of what has changed 
- [x] more small commits than less big commits 

## Code Checklist 
- [x] code is formatted appropriately 
- [x] code meets DRY standards
- [x] no dead code (check for logs and print statements)  
- [x] no TODOS instead necessary comments 
- [x] code follows Story Squad standards for:
     - Language 
     - Framework 
     - Libraries   

### PRs needs to be reviewed by at least 2 team members
 - TPL is the 3rd reviewer 
 - Lots of comments and suggestions, please! 

[Pull Request Rubric](https://www.notion.so/1fc04e4fedeb429ba873b7c68d281707?v=74054da7991341c0bf970f39410c43da) 
