### PR TITLE
Added done-reading button for audiobook page and its styling

### DIFF
--- a/src/components/pages/AudioBook/RenderAudioBook.js
+++ b/src/components/pages/AudioBook/RenderAudioBook.js
@@ -1,9 +1,7 @@
 import React, { useState } from 'react';
 import { Header } from '../../common';
-import { Row, Col } from 'antd';
 import { useHistory } from 'react-router-dom';
-import { InstructionsModal } from '../../common';
-import { modalInstructions } from '../../../utils/helpers';
+import { Button } from 'antd';
 import ReactAudioPlayer from 'react-h5-audio-player';
 import { PlayCircleOutlined, PauseCircleOutlined } from '@ant-design/icons';
 import 'react-h5-audio-player/lib/styles.css';
@@ -11,6 +9,12 @@ import 'antd/dist/antd.css';
 import './rhap-style-override.css';
 
 const RenderAudioBookContainer = () => {
+  const { push } = useHistory();
+
+  const doneReading = e => {
+    push('/child/draw');
+  };
+
   return (
     <>
       <Header displayMenu={true} />
@@ -25,6 +29,11 @@ const RenderAudioBookContainer = () => {
           pause: <PauseCircleOutlined />,
         }}
       />
+      <div className="done-reading-container">
+        <Button className="done-reading" type="button" onClick={doneReading}>
+          I’m awesome, I’m done reading!
+        </Button>
+      </div>
     </>
   );
 };

--- a/src/styles/less/AudioBook.less
+++ b/src/styles/less/AudioBook.less
@@ -1,0 +1,28 @@
+@import '~antd/dist/antd.less';
+@import '~antd/lib/style/themes/default.less';
+
+//Style for done-reading button
+.done-reading-container {
+    display: flex;
+    justify-content: center;
+    padding-bottom: 2%;
+    .done-reading {
+        display: flex;
+        flex-direction: row;
+        align-items: flex-start;
+        padding: 13px 17px;
+        font-family: Atma;
+        font-style: normal;
+        font-weight: 500;
+        font-size: 20px;
+        line-height: 24px;
+        color: #333D3E;
+        width:22%;
+        height:1%;
+        background: #8CE2E0;
+        border: 2px solid #333D3E;
+        box-sizing: border-box;
+        box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.1), inset 0px 1px 2px rgba(0, 0, 0, 0.05);
+        border-radius: 8px; 
+    }
+}

--- a/src/styles/less/index.less
+++ b/src/styles/less/index.less
@@ -40,6 +40,7 @@
 @import 'GalleryView';
 @import 'EditPlayers';
 @import 'NewChildCard';
+@import 'AudioBook';
 
 
 


### PR DESCRIPTION
- Added "done-reading" button for the RenderAudioBook Component
- OnClick on this "done-reading" button to route to the child/draw page. (Note- this page is yet to be designed).
- Added AudioBook.less styling for the button
- Removed unused import in RenderAudioBook Component
 
 
![Done_Reading_Button](https://user-images.githubusercontent.com/67390897/120742686-35257b80-c4ac-11eb-8298-9206137f129a.PNG)


