### PR TITLE
Feature/leaderboard to child gallery

### DIFF
--- a/src/components/pages/Gallery/WeeklySubmissions.js
+++ b/src/components/pages/Gallery/WeeklySubmissions.js
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import Weekly from './Weekly';
 
 const WeeklySubmissions = (props) => {
-  // const { authState } = useOktaAuth();
   
   // Passing state to Week Card. Displaying Week card in descending order.
   return (
@@ -11,9 +10,7 @@ const WeeklySubmissions = (props) => {
       {props.data.reverse().map((child, i) => {
         return (
           <Weekly key={i}
-            // childId={child.ID}
             sprint={child.sprint}
-            // galleryId={child.GalleryId}
             sourcestory={child.sprintStory}
             drawingprompt={child.DrawingPrompt}
             writingprompt={child.WritingPrompt}

--- a/src/components/pages/Gallery/WeeklySubmissions.js
+++ b/src/components/pages/Gallery/WeeklySubmissions.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import Weekly from './Weekly';
 
 const WeeklySubmissions = (props) => {
-  const { authState } = useOktaAuth();
+  // const { authState } = useOktaAuth();
   
   // Passing state to Week Card. Displaying Week card in descending order.
   return (

--- a/src/components/pages/Leaderboard/Leaderboard.js
+++ b/src/components/pages/Leaderboard/Leaderboard.js
@@ -47,7 +47,7 @@ const Leaderboard = props => {
     {
       title: 'Name',
       dataIndex: 'Name',
-      render: (Name, record) => (<Link to={`/gallery/`+record.ID}>{Name}</Link>),
+      render: (Name, record) => (<Link to={`/gallery/child`+record.ID}>{Name}</Link>),
       key: 'Name',
       width: 150,
     },

--- a/src/components/pages/Leaderboard/Leaderboard.js
+++ b/src/components/pages/Leaderboard/Leaderboard.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { Table } from 'antd';
 import { getLeaderboard } from '../../../api';
 import { useOktaAuth } from '@okta/okta-react/dist/OktaContext';
@@ -12,8 +13,6 @@ const Leaderboard = props => {
     //Getting data from backend for leaderboard
     getLeaderboard(authState).then(res => {
       setDataInfo(res);
-      console.log(res);
-      console.log();
     });
   }, [authState]);
 
@@ -48,6 +47,7 @@ const Leaderboard = props => {
     {
       title: 'Name',
       dataIndex: 'Name',
+      render: (Name, record) => (<Link to={`/gallery/`+record.ID}>{Name}</Link>),
       key: 'Name',
       width: 150,
     },


### PR DESCRIPTION
The feature has been added to gain access to the child's gallery page from the leaderboard.
The name within the leaderboard is now a link. Functionality works with the Ant Design module.

Thanks to Chucky who finished off the code for this task.

## Commits Checklist
- [ ] commits have clear title names 
- [ ] commit has descriptive message of what has changed 
- [ ] more small commits than less big commits 

## Code Checklist 
- [ ] code is formatted appropriately 
- [ ] code meets DRY standards
- [ ] no dead code (check for logs and print statements)  
- [ ] no TODOS instead necessary comments 
- [ ] code follows Story Squad standards for:
     - Language 
     - Framework 
     - Libraries   

### PRs needs to be reviewed by at least 2 team members
 - TPL is the 3rd reviewer 
 - Lots of comments and suggestions, please! 

[Pull Request Rubric](https://www.notion.so/1fc04e4fedeb429ba873b7c68d281707?v=74054da7991341c0bf970f39410c43da) 
