### PR TITLE
added conversion to pacific standard time in countdown timer

### DIFF
--- a/src/components/pages/HeadsUpDisplay/CountdownTimer.js
+++ b/src/components/pages/HeadsUpDisplay/CountdownTimer.js
@@ -1,21 +1,34 @@
-import React, { useState, useEffect } from 'react';
-import { CurrentActivity } from './CurrentActivity'
+import React, { useState, useEffect } from "react";
+import { CurrentActivity } from "./activity";
+import { NextActivity } from "./currentActivity";
 
 export const CountDownTimer = () => {
   // This function will calculate difference between current and target times
   const calculateTimeRemaining = () => {
     let currTime = new Date();
 
+    // This variable will format current local time to pacific timezone (string)
+    let pst = currTime.toLocaleString("en-US", {
+      timeZone: "America/Los_Angeles",
+      weekday: "short",
+      month: "short",
+      day: "2-digit",
+      year: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+      second: "numeric"
+    });
+
     // Set endTime to midnight each day, need to add logic for Saturday weekTwo to === 48 hours
     let endTime = new Date().setHours(24, 0, 0, 0);
-
-    let timeDiff = endTime - currTime;
+    // parse var pst, changing it from string to number format, then subtract from endTime
+    let timeDiff = endTime - Date.parse(pst);
 
     return timeDiff;
   };
 
   // This function will convert the format for our time difference to HH:MM:SS
-  const convertTimeFormat = time => {
+  const convertTimeFormat = (time) => {
     let timeVar = parseInt(time, 10);
 
     let hours = Math.floor(timeVar / (1000 * 60 * 60));
@@ -23,9 +36,9 @@ export const CountDownTimer = () => {
     let seconds = Math.floor(timeVar / 1000) % 60;
 
     return [hours, minutes, seconds]
-      .map(v => (v < 10 ? '0' + v : v))
-      .filter((v, i) => v !== '00' || i > 0)
-      .join(':');
+      .map((v) => (v < 10 ? "0" + v : v))
+      .filter((v, i) => v !== "00" || i > 0)
+      .join(":");
   };
 
   const [timeRemaining, setTimeRemaining] = useState(calculateTimeRemaining());
@@ -39,8 +52,9 @@ export const CountDownTimer = () => {
 
   return (
     <div className="countdown-timer">
-      <div>Current Activity: <CurrentActivity /></div>
-      <div>Time Remaining: {convertTimeFormat(timeRemaining)}</div>
+      <CurrentActivity />
+      <div>{convertTimeFormat(timeRemaining)}</div>
+      <NextActivity />
     </div>
   );
 };


### PR DESCRIPTION
# Description

This PR was created based on input from the stakeholders.  It was requested that the heads up display countdown timer be set to pacific standard timezone.  This is a single commit adding a variable to convert local time to PST, and then a conversion from string to number format for time remaining calculation.
