### PR TITLE
Set countdown timer to be relative to PST timezone

### DIFF
--- a/src/components/pages/HeadsUpDisplay/CountdownTimer.js
+++ b/src/components/pages/HeadsUpDisplay/CountdownTimer.js
@@ -19,8 +19,23 @@ export const CountDownTimer = () => {
       second: "numeric"
     });
 
-    // Set endTime to midnight each day, need to add logic for Saturday weekTwo to === 48 hours
-    let endTime = new Date().setHours(24, 0, 0, 0);
+    let endTime = new Date();
+    let today = new Date().getDay();
+
+    console.log(today);
+
+    const countdownVar = {
+      0: 24,
+      1: 72,
+      2: 48,
+      3: 24,
+      4: 24,
+      5: 24,
+      6: 48
+    };
+
+    // Set endTime based on day of week (72, 48, 25 hour timers)
+    endTime.setHours(countdownVar[today], 0, 0, 0);
     // parse var pst, changing it from string to number format, then subtract from endTime
     let timeDiff = endTime - Date.parse(pst);
 

--- a/src/components/pages/HeadsUpDisplay/CountdownTimer.js
+++ b/src/components/pages/HeadsUpDisplay/CountdownTimer.js
@@ -1,21 +1,34 @@
-import React, { useState, useEffect } from 'react';
-import { CurrentActivity } from './CurrentActivity'
+import React, { useState, useEffect } from "react";
+import { CurrentActivity } from "./activity";
+import { NextActivity } from "./currentActivity";
 
 export const CountDownTimer = () => {
   // This function will calculate difference between current and target times
   const calculateTimeRemaining = () => {
     let currTime = new Date();
 
+    // This variable will format current local time to pacific timezone (string)
+    let pst = currTime.toLocaleString("en-US", {
+      timeZone: "America/Los_Angeles",
+      weekday: "short",
+      month: "short",
+      day: "2-digit",
+      year: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+      second: "numeric"
+    });
+
     // Set endTime to midnight each day, need to add logic for Saturday weekTwo to === 48 hours
     let endTime = new Date().setHours(24, 0, 0, 0);
-
-    let timeDiff = endTime - currTime;
+    // parse var pst, changing it from string to number format, then subtract from endTime
+    let timeDiff = endTime - Date.parse(pst);
 
     return timeDiff;
   };
 
   // This function will convert the format for our time difference to HH:MM:SS
-  const convertTimeFormat = time => {
+  const convertTimeFormat = (time) => {
     let timeVar = parseInt(time, 10);
 
     let hours = Math.floor(timeVar / (1000 * 60 * 60));
@@ -23,9 +36,9 @@ export const CountDownTimer = () => {
     let seconds = Math.floor(timeVar / 1000) % 60;
 
     return [hours, minutes, seconds]
-      .map(v => (v < 10 ? '0' + v : v))
-      .filter((v, i) => v !== '00' || i > 0)
-      .join(':');
+      .map((v) => (v < 10 ? "0" + v : v))
+      .filter((v, i) => v !== "00" || i > 0)
+      .join(":");
   };
 
   const [timeRemaining, setTimeRemaining] = useState(calculateTimeRemaining());
@@ -39,8 +52,9 @@ export const CountDownTimer = () => {
 
   return (
     <div className="countdown-timer">
-      <div>Current Activity: <CurrentActivity /></div>
-      <div>Time Remaining: {convertTimeFormat(timeRemaining)}</div>
+      <CurrentActivity />
+      <div>{convertTimeFormat(timeRemaining)}</div>
+      <NextActivity />
     </div>
   );
 };


### PR DESCRIPTION
# Description

This PR was created based on input from the stakeholders; it was requested that the heads up display countdown timer be based on PST, universally for all users.  The 'currTime' variable was set to PST, setting the countdown to be relative to the PST timezone rather than user's timezone.  Also added in this PR was a countdown variable that would align with the stakeholders' vision of game timelines:
- Days 1 - 3 will now count down together, starting at 72 hour countdown, allowing the user to see how much time remains for all 3 activities (read, draw, write)
- Days 4 & 5 remain 24 hour countdowns (squadding up, point share)
- Days 6 - 7 will now count down together, starting at 48 hour countdown, allowing the user to see how much time remains for both activities (voting, big final reveal)

## Commits Checklist
- [x] commits have clear title names 
- [x] commit has descriptive message of what has changed 
- [x] more small commits than less big commits 

## Code Checklist 
- [x] code is formatted appropriately 
- [x] code meets DRY standards
- [x] no dead code (check for logs and print statements)  
- [x] no TODOS instead necessary comments 
- [x] code follows Story Squad standards for:
     - Language 
     - Framework 
     - Libraries   
