### PR TITLE
Undefined variable in the PointShare component is preventing the the app from rendering

### DIFF
--- a/src/components/pages/PointShare/RenderPointShare.js
+++ b/src/components/pages/PointShare/RenderPointShare.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useOktaAuth } from '@okta/okta-react/dist/OktaContext';
 import { Header } from '../../common';


### PR DESCRIPTION
## Description

There's an undefined variable in the PointShare component that is preventing the the app from rendering when started.

- What work was done?
Added missing useCallback hook to the RenderPointShare.js file

- Why was this work done?
It was necessary to clear the bug in order to have the app running

- Relevant Links
loom video: https://www.loom.com/share/d745a60d49fc471db22c05402ffb340c


