### PR TITLE
Bugfix/ change to html for

### DIFF
--- a/src/components/pages/ParentContact/ParentContactContainer.js
+++ b/src/components/pages/ParentContact/ParentContactContainer.js
@@ -68,7 +68,7 @@ const ParentContactContainer = () => {
             <form className="contact-form-container" onSubmit={handleSubmit}>
               <Row className="form-inputs">
                 <Col>
-                  <label for="name">Name</label>
+                  <label htmlFor="name">Name</label>
                   <br />
                   <input
                     type="text"
@@ -80,7 +80,7 @@ const ParentContactContainer = () => {
                   />
                 </Col>
                 <Col>
-                  <label for="email">Email Address</label>
+                  <label htmlFor="email">Email Address</label>
                   <br />
                   <input
                     type="email"
@@ -93,7 +93,7 @@ const ParentContactContainer = () => {
                 </Col>
               </Row>
               <Row>
-                <label for="message">Message</label>
+                <label htmlFor="message">Message</label>
                 <br />
                 <textarea
                   id="message"

--- a/src/components/pages/WordCloud/index.js
+++ b/src/components/pages/WordCloud/index.js
@@ -34,7 +34,7 @@ function RenderWordCloud() {
             checked={cloud === 'cropcloud'}
             defaultChecked
           />
-          <label for="cropcloud" className="switcher__label">
+          <label htmlFor="cropcloud" className="switcher__label">
             Crop Cloud
           </label>
 
@@ -47,7 +47,7 @@ function RenderWordCloud() {
             onChange={() => handleButtonPress(2)}
             checked={cloud === 'wordcloud'}
           />
-          <label for="wordcloud" className="switcher__label">
+          <label htmlFor="wordcloud" className="switcher__label">
             Word Cloud
           </label>
 


### PR DESCRIPTION
This pull request is meant to fix the htmlFor references in the codebase that were iterated as for in the label components of WordCloud/index.js lines 37 and 50 as well as ParentContactContainer.js lines 71, 83, 96
Pair coded with Rhiannon
this is in reference to trello card: https://trello.com/c/g02KLUd7  
the video for the pr is located: https://youtu.be/8zTXURroKys

original package-lock deletion created additional issues. Deleted original PR. Re-cloned project, fixed issues again. Should be good to go now. 

Co-authored-by : @Qirhi 