### PR TITLE
Bug/repair game draw step and upload docs warnings redo

### DIFF
--- a/src/components/common/UploadDocs.js
+++ b/src/components/common/UploadDocs.js
@@ -114,7 +114,7 @@ export const UploadDocs = ({
     console.log({ fileList, filePreviews }, 'useEffect');
 
     // This is in case I have a filelist ready OUTSIDE this component
-    if (savedFileList != undefined) {
+    if (savedFileList !== undefined) {
       setFilePreviews(savedFileList);
       setFileList(savedFileList);
     }

--- a/src/components/common/UploadDocs.js
+++ b/src/components/common/UploadDocs.js
@@ -118,7 +118,7 @@ export const UploadDocs = ({
       setFilePreviews(savedFileList);
       setFileList(savedFileList);
     }
-  });
+  }, [fileList, filePreviews, savedFileList]);
 
   // For error message warning if there are too many images
   const openNotificationWithIcon = type => {

--- a/src/components/pages/GamePlay/GameDrawStep.js
+++ b/src/components/pages/GamePlay/GameDrawStep.js
@@ -97,7 +97,7 @@ export default function GameDrawStep(props) {
     });
 
     setFileList(props.fileSubmissionData.drawings);
-  }, []);
+  }, [props.fileSubmissionData.drawings]);
 
   return (
     <div id="draw-step">

--- a/src/components/pages/GamePlay/GameDrawStep.js
+++ b/src/components/pages/GamePlay/GameDrawStep.js
@@ -103,7 +103,7 @@ export default function GameDrawStep(props) {
     <div id="draw-step">
       <div id="draw" className="gameplay-content">
         <div className="inner-container">
-          <img src={boyImg} alt="Boy Image" className="boy-img" />
+          <img src={boyImg} alt="A boy" className="boy-img" />
 
           <div className="step-description">
             <h3>Don’t forget!</h3>


### PR DESCRIPTION
In the gameDrawStep.js component there were two warnings that needed to be addressed.
One was a useEffect dependancy warning and the other was a alt text warning on the image element. The useEffect warning was the most important because there was a missing argument in the dependency array on line 100 that was causing performance issues for the application. I added the missing argument of the prop for the file submission drawing and performance has increased significantly. The alt text warning on line 106 was minor in that the text inside the string was redundant in its wording . I made a slight change to the text to repair the warning.

In the UploadDocs component, there was a missing dependency list for the dependency array on line 121. I added the 3 missing arguments to repair the warning. The next warning involved improper syntax for a condition on line 117. This was minor; I corrected the syntax and the warning disappeared.


PR submission video: https://drive.google.com/file/d/16qV51pYEe2fl_dFQeM4Ij9BnwsG62fCW/view?usp=sharing