### PR TITLE
Adjust styling to child dashboard gallery container

### DIFF
--- a/src/components/pages/ChildDashboard/RenderChildDashboard.js
+++ b/src/components/pages/ChildDashboard/RenderChildDashboard.js
@@ -53,36 +53,48 @@ const RenderChildDashboard = props => {
           <Col
             className="accept-mission"
             xs={24}
-            sm={13}
+            sm={12}
             onClick={handleAcceptMission}
           >
             <p className="accept-mission-text">ACCEPT THE MISSION!</p>
           </Col>
-          <Col className="change-avatar" xs={24} sm={11}>
+          <Col
+            className="change-avatar"
+            xs={24}
+            sm={12}
+            onClick={handleAdminPage}
+          >
             <img
               className="child-dash-img"
               src={change_your_avatar}
               alt="Change Your Avatar Button"
-              onClick={handleAdminPage}
             />
           </Col>
         </Row>
         <Row className="bottomrow">
-          <Col className="adventure-passport" xs={24} sm={11}>
+          <Col
+            className="adventure-passport"
+            xs={24}
+            sm={12}
+            onClick={handleJoinSquad}
+          >
             <img
               className="child-dash-img"
               src={adventure_passport}
               alt="Adventure Passport Button"
-              onClick={handleJoinSquad}
             />
           </Col>
-          <Col className="leaderboard" xs={24} sm={13}>
+          <Col
+            className="leaderboard"
+            xs={24}
+            sm={12}
+            onClick={handleLeaderboard}
+          >
             <img
               className="child-dash-img"
               // This icon will need to be changed to an inhouse icon, this is just imported as a placeholder //
               src={leaderboard_icon}
               alt="Leaderboard Button"
-              onClick={handleLeaderboard}
             />
           </Col>
         </Row>

--- a/src/styles/less/ChildDashboard.less
+++ b/src/styles/less/ChildDashboard.less
@@ -29,6 +29,8 @@
     height: 35vh;
   }
 
+
+
   .accept-mission {
     background: url('../../assets/images/child_dashboard_images/accept_the_mission.svg')
       no-repeat;
@@ -46,7 +48,43 @@
     }
   }
 
-  
+  div.accept-mission {
+    border-width: .75rem .375rem .75rem .75rem;
+    @media @tablet {
+      border-width: .5rem .25rem .5rem .5rem;
+    }
+    @media @mobile {
+      border-width: .5rem .5rem .25rem .5rem;
+    }
+  }
+  div.change-avatar {
+    border-width: .75rem .75rem .75rem .375rem;
+    @media @tablet {
+      border-width: .5rem .5rem .5rem .25rem;
+    }
+    @media @mobile {
+      border-width: .25rem .5rem .5rem .5rem;
+    }
+  }
+  div.adventure-passport {
+    border-width: .75rem .375rem .75rem .75rem;
+    @media @tablet {
+      border-width: .5rem .25rem .5rem .5rem;
+    }
+    @media @mobile {
+      border-width: .5rem .5rem .25rem .5rem;
+    }
+  }
+  div.leaderboard {
+    border-width: .75rem .75rem .75rem .375rem;
+    @media @tablet {
+      border-width: .5rem .5rem .5rem .25rem;
+    }
+    @media @mobile {
+      border-width: .25rem .5rem .5rem .5rem;
+    }
+  }
+
 // Gamemode could use backend read write examples intohere
   .accept-mission-ga1 {
     background: url('../../assets/images/child_dashboard_images/accept_the_mission.svg')


### PR DESCRIPTION
This pull request resolves styling updates to the child dashboard gallery container. 

1) Align cards - adjust Ant Design column element to sm={12}
2) Increase card border to .75rem (desktop) and .5rem (mobile)
3) Adjust clickable areas - move onClick to parent Col element
4) Add responsiveness - media queries added to ChildDashboard.less for container divs


Resolves Trello card: https://trello.com/c/LEnDVmG4/519-child-dashboard-update-styling-on-dashboard-container
PR video walkthrough: https://www.youtube.com/watch?v=UdMGI70uMWM


Pair-programmed  & Co-authored with Tony : @artofmayhem 