### PR TITLE
FIXES: trello card defined but not used c

### DIFF
--- a/src/components/pages/WordCloud/CropCloud.js
+++ b/src/components/pages/WordCloud/CropCloud.js
@@ -1,12 +1,18 @@
-import React, { useEffect, useState } from 'react';
-import axios from 'axios';
+// TEMPORARY - REMOVED useEffect, useState while not in use. Replace when useEffect block is needed
+import React from 'react';
+// TEMPORARY - COMMENTED OUT axios while not in use. Replace when useEffect block is needed
+// import axios from 'axios';
+
 // Placeholder CropCloud to render in case endpoints do not get finished in time
 import { placeholderCloud } from './data';
 
 export default function CropCloud() {
   // Sets our baseurl to the API from DS to generate the base64 encoded crop cloud
-  const baseURL = 'placeholder';
-  const [cloudImg, setCloudImg] = useState(null);
+
+  // TEMPORARY - COMMENTED OUT baseURL while not in use. Uncomment when useEffect block is needed
+  // const baseURL = 'placeholder';
+  // TEMPORARY - COMMENTED OUT cloudImg useState while not in use. Uncomment when useEffect block is needed
+  // const [cloudImg, setCloudImg] = useState(null);
 
   // Placeholder API Call to get the CropCloud once the endpoint is working
   // useEffect(() =>{


### PR DESCRIPTION
This FIXES trello card C issues of removing defined but unused imports and variables due to the commenting out of the useEffect block to get the CropCloud once the endpoint is working

REMOVED : 
useEffect
useState

COMMENTED OUT with temporary tags
import axios
const baseURL
const [cloudImg, setCloudImg]

REFERENCING:
https://trello.com/c/eSBjzj7M

VIDEO PR: 
https://youtu.be/zl-QHxbaito
