### PR TITLE
Created Crop/Word Cloud Container 

### DIFF
--- a/src/components/pages/WordCloud/CropCloud.js
+++ b/src/components/pages/WordCloud/CropCloud.js
@@ -25,10 +25,12 @@ export default function CropCloud() {
   return (
     <div className="cropcloud">
       {/* The first portion of the "src" code is a built in method for decoding images, just change the file type for different img types */}
-      <img
-        className={'cropcloudimage'}
-        src={`data:image/png;base64, ${placeholderCloud.data}`}
-      />
+      <div className="crop-cloud-container">
+        <img
+          className={'cropcloudimage'}
+          src={`data:image/png;base64, ${placeholderCloud.data}`}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/pages/WordCloud/wordcloud.css
+++ b/src/components/pages/WordCloud/wordcloud.css
@@ -77,12 +77,15 @@
   width: 725px;
   background-color: #b5d33d;
   border-radius: 111px;
+  filter: drop-shadow(0 0.25rem 0.25rem #949494);
+  border: 3px solid black;
 }
 
 .cropcloudimage {
   height: 500px;
   width: auto;
   border-radius: 111px;
+  filter: drop-shadow(0 0 0.25rem #949494);
 }
 
 /* Toggle Switch Styling */

--- a/src/components/pages/WordCloud/wordcloud.css
+++ b/src/components/pages/WordCloud/wordcloud.css
@@ -69,10 +69,20 @@
   justify-content: center;
   align-items: center;
 }
+.crop-cloud-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 615px;
+  width: 725px;
+  background-color: #b5d33d;
+  border-radius: 111px;
+}
 
 .cropcloudimage {
   height: 500px;
   width: auto;
+  border-radius: 111px;
 }
 
 /* Toggle Switch Styling */


### PR DESCRIPTION
## Description
Created div container for crop cloud image, and styled it to get as close to UI specifications as feasible. This component is needed to surround the word (crop) cloud and draw attention to it, and serve as a decoration. This is more appealing from a UI and UX perspective. 

Add a summary that address the following:

- motivation/purpose for the feature
 Stylize the container surrounding the crop/word cloud image 
 - What were those changes
 I created a div inside of the crop cloud div, and then adjusted width and height to ensure that there was the padding needed to surround the crop cloud image. Then I used border radius at 111px to create the marshmellow looking shape. 
- What issues were fixed
By adding this it breaks up the sea of white background, and brings the users attention to the crop cloud. 
- Provide the link to the user story it is referencing in Trello board or other supporting document
  https://trello.com/c/szLwC13f
-Loom Video
https://www.loom.com/share/6b33e1f561194a37bc662b6fbefe5deb

## Commits Checklist

- [ X] commits have clear title names
- [ X] commit has descriptive message of what has changed
- [ X ] more small commits than less big commits (single commit for minimal changes)

## Code Checklist

- [X ] code is formatted appropriately
- [X ] code meets DRY standards
- [X ] no dead code (check for logs and print statements)
- [X ] no TODOS instead necessary comments
- [X ] code follows Story Squad standards for:
  - Language
  - Framework
  - Libraries

### PRs needs to be reviewed by at least 2 team members

- TPL is the 3rd reviewer
- Lots of comments and suggestions, please!

[Pull Request Rubric](https://www.notion.so/1fc04e4fedeb429ba873b7c68d281707?v=74054da7991341c0bf970f39410c43da)
