### PR TITLE
Bug/repair warnings for game write step and src index

### DIFF
--- a/src/components/pages/GamePlay/GameWriteStep.js
+++ b/src/components/pages/GamePlay/GameWriteStep.js
@@ -109,7 +109,7 @@ export default function GameWriteStep(props) {
     <div id="write-step">
       <div id="write" className="gameplay-content">
         <div className="inner-container">
-          <img src={boyImg} alt="Boy Image" className="boy-img" />
+          <img src={boyImg} alt="A boy" className="boy-img" />
 
           <div className="step-description">
             <h3>Don’t forget!</h3>

--- a/src/index.js
+++ b/src/index.js
@@ -128,14 +128,12 @@ function App() {
             <StoryPrompt LoadingComponent={ChildLoadingComponent} />
           )}
         />
-
         <ProtectedRoute
           path="/child/dashboard"
           component={() => (
             <ChildDashboard LoadingComponent={ChildLoadingComponent} />
           )}
         />
-
         <ProtectedRoute
           exact
           path="/gallery"
@@ -143,7 +141,6 @@ function App() {
             <GalleryContainer LoadingComponent={ChildLoadingComponent} />
           )}
         />
-
         <ProtectedRoute
           exact
           path="/gallery/:id"
@@ -151,7 +148,6 @@ function App() {
             <GalleryContainer LoadingComponent={ChildLoadingComponent} />
           )}
         />
-
         <ProtectedRoute
           exact
           path="/gallery/child/:id"
@@ -159,9 +155,7 @@ function App() {
             <GalleryContainer LoadingComponent={ChildLoadingComponent} />
           )}
         />
-
         <ProtectedRoute path="/scoreboard" component={FaceoffReveal} />
-
         <ProtectedRoute
           path="/child/mission-control"
           component={() => (
@@ -199,20 +193,16 @@ function App() {
             <NewParentDashboard LoadingComponent={ParentLoadingComponent} />
           )}
         />
-
         <ProtectedRoute
           exact
           path="/parent/dashboard-faq"
           component={() => (
             <ParentDashFaq LoadingComponent={ParentLoadingComponent} />
           )}
-          exact
-          path="/parent/support"
-          component={() => (
-            <SupportPage LoadingComponent={ParentLoadingComponent} />
-          )}
         />
-
+        exact path="/parent/support" component=
+        {() => <SupportPage LoadingComponent={ParentLoadingComponent} />}
+        />
         <ProtectedRoute
           exact
           path="/parent/faq"
@@ -227,7 +217,6 @@ function App() {
             <ParentContact LoadingComponent={ParentLoadingComponent} />
           )}
         />
-
         <ProtectedRoute
           exact
           path="/parent/help"

--- a/src/index.js
+++ b/src/index.js
@@ -128,12 +128,14 @@ function App() {
             <StoryPrompt LoadingComponent={ChildLoadingComponent} />
           )}
         />
+
         <ProtectedRoute
           path="/child/dashboard"
           component={() => (
             <ChildDashboard LoadingComponent={ChildLoadingComponent} />
           )}
         />
+
         <ProtectedRoute
           exact
           path="/gallery"
@@ -141,6 +143,7 @@ function App() {
             <GalleryContainer LoadingComponent={ChildLoadingComponent} />
           )}
         />
+
         <ProtectedRoute
           exact
           path="/gallery/:id"
@@ -148,6 +151,7 @@ function App() {
             <GalleryContainer LoadingComponent={ChildLoadingComponent} />
           )}
         />
+
         <ProtectedRoute
           exact
           path="/gallery/child/:id"
@@ -155,7 +159,9 @@ function App() {
             <GalleryContainer LoadingComponent={ChildLoadingComponent} />
           )}
         />
+
         <ProtectedRoute path="/scoreboard" component={FaceoffReveal} />
+
         <ProtectedRoute
           path="/child/mission-control"
           component={() => (
@@ -193,6 +199,7 @@ function App() {
             <NewParentDashboard LoadingComponent={ParentLoadingComponent} />
           )}
         />
+
         <ProtectedRoute
           exact
           path="/parent/dashboard-faq"
@@ -200,9 +207,14 @@ function App() {
             <ParentDashFaq LoadingComponent={ParentLoadingComponent} />
           )}
         />
-        exact path="/parent/support" component=
-        {() => <SupportPage LoadingComponent={ParentLoadingComponent} />}
+        <ProtectedRoute
+          exact
+          path="/parent/support"
+          component={() => (
+            <SupportPage LoadingComponent={ParentLoadingComponent} />
+          )}
         />
+
         <ProtectedRoute
           exact
           path="/parent/faq"
@@ -217,6 +229,7 @@ function App() {
             <ParentContact LoadingComponent={ParentLoadingComponent} />
           )}
         />
+
         <ProtectedRoute
           exact
           path="/parent/help"


### PR DESCRIPTION
In this ticket, I resolved several warnings:
./src/index.js
Line 210:11: No duplicate props allowed
Line 211:11: No duplicate props allowed
Line 212:11: No duplicate props allowed

./src/components/pages/GamePlay/GameWriteStep.js
Line 112:11: Redundant alt attribute. Screen-readers already announce img tags as an image. You don’t need to use the words image, photo, or picture (or any specified custom words) in the alt prop

We had three warnings about duplicates in the index.js file. I checked the codebase and as it turns out, there are no duplicates. The real issue was improper syntax with the ProtectedRoute components on lines 210-211-212. One ProtectedRoute tag was not closed and the other ProtectedRoute on line 212 didn't have a tag at all. I closed the first tag on line 210 and added the ProtectedRoute tag to the ProtectedRoute on line 212. That resolved the issues in this file.

In the GameWriteStep.js file, there was an img element on #112 that had the word "image" in the text of the alt attribute. I changed the text to "A boy" and that resolved the warning.
----------------------------------------------------------------------------------------------------
Trello card: https://trello.com/c/yecJDBnN/617-other-warnings-and-error-d
PR submission vid: https://drive.google.com/file/d/1a4qoj5adWA-_wqFbN7LeUyFIBJ0cT1-m/view?usp=sharing

