### PR TITLE
Bug/repair warnings for your mision comp and moderation test

### DIFF
--- a/src/components/pages/Gamemode/YourMissionComp.js
+++ b/src/components/pages/Gamemode/YourMissionComp.js
@@ -58,7 +58,7 @@ const YourMissionComp = ({ ...props }) => {
         className={rwd.write === true ? 'rectangle130-yellow' : 'rectangle130'}
       >
         <Row className="btmRow">
-          <img src={LightingKid} alt="A lighting kid" />
+          <img src={LightingKid} alt="A child dressed as a superhero called lighting kid" />
           <Col>
             <h1 className="dont4get">DON'T FORGET!</h1>
 

--- a/src/components/pages/Gamemode/YourMissionComp.js
+++ b/src/components/pages/Gamemode/YourMissionComp.js
@@ -58,7 +58,7 @@ const YourMissionComp = ({ ...props }) => {
         className={rwd.write === true ? 'rectangle130-yellow' : 'rectangle130'}
       >
         <Row className="btmRow">
-          <img src={LightingKid} />
+          <img src={LightingKid} alt="A lighting kid" />
           <Col>
             <h1 className="dont4get">DON'T FORGET!</h1>
 

--- a/src/components/pages/ModerationTest/ModerationTest.js
+++ b/src/components/pages/ModerationTest/ModerationTest.js
@@ -210,7 +210,7 @@ const ModerationTest = props => {
             THIS ROUTE IS DEPRECIATED. PLEASE USE/WORK ON{' '}
             <Link to="/admin">`/admin`</Link> INSTEAD OF `/moderation`
           </h1>
-          <h1></h1>
+
           <Form form={form} className="inline-form">
             <Button type="default" onClick={homePageHandler}>
               Back to Home Page


### PR DESCRIPTION
In this ticket, I resolved two warnings.

./src/components/pages/Gamemode/YourMissionComp.js
Line 61:11: img elements must have an alt prop, either with meaningful text, or an empty string for decorative images

./src/components/pages/ModerationTest/ModerationTest.js
Line 213:11: Headings must have content and the content must be accessible by a screen reader

The first warning was in the YourMissionComp component. There was a missing alt attribute in the img element. I added the alt attribute with descriptive text and that resolved the issue.

The second warning was an empty h1 element in the ModerationTest component. I checked the codebase to see if this element was potentially going to be used but found no use for this element. I deleted it and the warning was resolved.

---------------------------------------------------------------------------------------------
PR submission video: https://drive.google.com/file/d/14hSlZ7PQzJB3VKZ3QK-dTm9-kMFOo72b/view?usp=sharing
Trello card: https://trello.com/c/IH2fFWuK/615-other-warnings-and-error-b