### PR TITLE
Bug/repair warnings for unrecognized prop game draw step and crop cloud

### DIFF
--- a/src/components/pages/WordCloud/CropCloud.js
+++ b/src/components/pages/WordCloud/CropCloud.js
@@ -34,6 +34,7 @@ export default function CropCloud() {
       <img
         className={'cropcloudimage'}
         src={`data:image/png;base64, ${placeholderCloud.data}`}
+        alt="A crop cloud"
       />
     </div>
   );

--- a/src/components/pages/WordCloud/CropCloud.js
+++ b/src/components/pages/WordCloud/CropCloud.js
@@ -34,7 +34,7 @@ export default function CropCloud() {
       <img
         className={'cropcloudimage'}
         src={`data:image/png;base64, ${placeholderCloud.data}`}
-        alt="A crop cloud"
+        alt="A demonstration of a child's handwritten words"
       />
     </div>
   );

--- a/src/components/pages/WordCloud/index.js
+++ b/src/components/pages/WordCloud/index.js
@@ -21,7 +21,7 @@ function RenderWordCloud() {
   }
 
   return (
-    <div classNameName="wordCloudContainer">
+    <div className="wordCloudContainer">
       <div className="centerer">
         <div className="switcher">
           <input


### PR DESCRIPTION
In this ticket I have one warning:
Unrecognized prop classNameName appears on the DOM.

This warning was originating from #24 of the div element from the index.js file the in WordCloud directory.
This was minor, just a syntax error. I corrected the mistake and the warning was resolved.

Trello Card:  https://trello.com/c/DNJ6Nota/620-unrecognized-prop-on-dom-element

-------------------------------------------------------------------------------------------------
In this ticket, there were two warnings to be repaired.

./src/components/pages/Gameification/GameDrawStep.js
Line 106:11: Redundant alt attribute. Screen-readers already announce img tags as an image. You don’t need to use the words image, photo, or picture (or any specified custom words) in the alt prop

./src/components/pages/WordCloud/CropCloud.js
Line 28:7: img elements must have an alt prop, either with meaningful text, or an empty string for decorative images

The first warning was already resolved in a previous ticket, I think it was put into this ticket by mistake.
The second one was an img element on line 28 that was missing an alt attribute. What I did was added the attribute in with some descriptive text and that resolved the issue.

Trello Card : https://trello.com/c/7CJSTPma/614-other-warnings-and-error-a

--------------------------------------------------------------------------------------------
PR submission video: https://drive.google.com/file/d/1P7VYNxBOg9py5FHMxUKEK9TNO88vGsXg/view?usp=sharing