### PR TITLE
Bug/repair warnings for gamemode renderpointshare useenlargementcentertotopleft

### DIFF
--- a/src/components/pages/Animations/AnimationComponents/useEnlargeCenterToTopLeft.js
+++ b/src/components/pages/Animations/AnimationComponents/useEnlargeCenterToTopLeft.js
@@ -4,7 +4,6 @@ import useMedia from '../AnimationMediaHelper/useMedia';
 const useEnlargeCenterToTopLeft = ref => {
   const phoneScreen = useMedia('(max-width:600px)');
   const tabletScreen = useMedia('(max-width:991px)');
-  const computerScreen = useMedia('(min-width:992px)');
 
   const spring = useSpring({
     config: { mass: 10, tension: 500, friction: 150 },

--- a/src/components/pages/Gamemode/Gamemode.js
+++ b/src/components/pages/Gamemode/Gamemode.js
@@ -5,7 +5,7 @@ import { Row, Col, Button } from 'antd';
 import { connect } from 'react-redux';
 
 import { useHistory } from 'react-router-dom';
-import { BrowserRouter as Router, Link, Route, Switch } from 'react-router-dom';
+import { Link, Route } from 'react-router-dom';
 import GamemodeButton from './GamemodeButton';
 
 const Gamemode = ({ ...props }) => {


### PR DESCRIPTION
In this ticket, I'm repairing warnings for the GameMode, RenderPointShare, and UseEnlargementCenterToTopLeft components.
-----------------------------------------------------------------------------------------------------------
./src/components/pages/Animations/AnimationComponents/useEnlargeCenterToTopLeft.js
Line 7:9: 'computerScreen' is assigned a value but never used no-unused-vars

./src/components/pages/Gamemode/Gamemode.js
Line 8:27: 'Router' is defined but never used no-unused-vars
Line 8:48: 'Switch' is defined but never used

./src/components/pages/PointShare/RenderPointShare.js
Line 45:9: 'setVirtualPlayerPoints' is assigned a value but never used

----------------------------------------------------------------------------------------------

In the useEnlargeCenterToTopLeft component, there was a defined const called "computer screen" that was defined on line 7 but was never implemented. I removed the const and the warning was resolved.

In the Gamemode component, there was two imports, browserRouter as Router and Switch, that resided on line *8 in which I removed.  For browserRouter, that shouldn't have been there. That's something that wraps around the application, I'm not sure why that was imported there.
Same thing goes for Switch, that isn't meant to be there. In any case, I removed them and the warnings were resolved.

In RenderPointShare component, there a const called setVirtualPlayerPoints that was declared and defined but was never used. It appears that it sets the points of the virtual players. There's very good reason to remove it because on line 87 there's another const called setVirtualPlayerCallback that appears to be doing the exact same thing. This const is passed in to the submitPoints call on line 115 and 117.

Now the question is why didn't I remove it? Well, it's a big block of code and maybe there's some implementation that I didn't consider. In any case, I think it should be removed but I'd like for a reviewer to look at it before the removal just to be safe.

Trello card: https://trello.com/c/lmgnqOwg/608-defined-but-never-used-k
--------------------------------------------------------------------------------------
PR submission video: https://drive.google.com/file/d/1LukZGYe5NVZ9jmhAAcfjWSl9hab9g6ed/view?usp=sharing