### PR TITLE
Bugs/daycomponents/05 wed error fixes

### DIFF
--- a/src/components/pages/AdminDashboard/DevTools/DayComponents/05_Wed.js
+++ b/src/components/pages/AdminDashboard/DevTools/DayComponents/05_Wed.js
@@ -35,8 +35,6 @@ const Wed = ({ setDate }) => {
   useEffect(() => {
     setDate(findNextDayOfWeek(findDayOfWeekReference));
   }, [setDate]);
-  //the dependency array on line 37 was originally set to [findDayOfWeekReference] which was causing error
-
   return (
     <Layout>
       <Header className="ant-page-header">

--- a/src/components/pages/AdminDashboard/DevTools/DayComponents/05_Wed.js
+++ b/src/components/pages/AdminDashboard/DevTools/DayComponents/05_Wed.js
@@ -34,7 +34,8 @@ const Wed = ({ setDate }) => {
 
   useEffect(() => {
     setDate(findNextDayOfWeek(findDayOfWeekReference));
-  }, [findDayOfWeekReference]);
+  }, [setDate]);
+  //the dependency array on line 37 was originally set to [findDayOfWeekReference] which was causing error
 
   return (
     <Layout>

--- a/src/components/pages/AdminDashboard/DevTools/DayComponents/07_Fri.js
+++ b/src/components/pages/AdminDashboard/DevTools/DayComponents/07_Fri.js
@@ -34,7 +34,8 @@ const Fri = ({ setDate }) => {
 
   useEffect(() => {
     setDate(findNextDayOfWeek(findDayOfWeekReference));
-  }, [findDayOfWeekReference]);
+  }, [setDate]);
+  //the dependency array was originally set to [findDayOfWeekReference]. Had to be changed
 
   return (
     <Layout>

--- a/src/components/pages/AdminDashboard/DevTools/DayComponents/07_Fri.js
+++ b/src/components/pages/AdminDashboard/DevTools/DayComponents/07_Fri.js
@@ -35,7 +35,6 @@ const Fri = ({ setDate }) => {
   useEffect(() => {
     setDate(findNextDayOfWeek(findDayOfWeekReference));
   }, [setDate]);
-  //the dependency array was originally set to [findDayOfWeekReference]. Had to be changed
 
   return (
     <Layout>


### PR DESCRIPTION
This PR corrects the following Missing Dependency Array Errors :

./src/components/pages/AdminDashboard/DevTools/DayComponents/05_Wed.js
Line 37:6: React Hook useEffect has a wrong dependency array: -> Corrected

./src/components/pages/AdminDashboard/DevTools/DayComponents/07_Fri.js
Line 37:6: React Hook useEffect has a wrong dependency: -> Corrected

All of the above fixes can be achieved either including the "setDate" in the dependency array or entirely removing the dependency array. If the "setDate" changes too often, then we need to find the parent component that defines it and wrap that in useCallback, but in our case we don't need to worry about that, since "setDate" does not change that often.
Resolves Trello card: https://trello.com/c/GAEyXwXD/596-useeffect-missing-dependencies-warnings-d
PR video walkthrough: https://www.loom.com/share/5c5b80448a094b2e8d226be54df72dbe
