### PR TITLE
Bug Fix: Missing return statement in arrow functions

### DIFF
--- a/src/components/pages/AccountSettings/RenderAccountSettings.js
+++ b/src/components/pages/AccountSettings/RenderAccountSettings.js
@@ -16,11 +16,7 @@ function RenderAccountSettings() {
   //Grab the parents userInfo so we can validate their information (pin)
   useEffect(() => {
     getProfileData(user).then(res => {
-      res.map(user => {
-        if (user.type === 'Parent') {
-          setUserInfo(user);
-        }
-      });
+      res.filter(user => setUserInfo(user) && user.type === 'Parent');
     });
   }, [user]);
 

--- a/src/components/pages/AccountSettings/RenderAccountSettings.js
+++ b/src/components/pages/AccountSettings/RenderAccountSettings.js
@@ -16,7 +16,10 @@ function RenderAccountSettings() {
   //Grab the parents userInfo so we can validate their information (pin)
   useEffect(() => {
     getProfileData(user).then(res => {
-      res.filter(user => setUserInfo(user) && user.type === 'Parent');
+      const parent = res.find(user => user.type === 'Parent');
+      if (parent !== null) {
+        setUserInfo(parent);
+      }
     });
   }, [user]);
 

--- a/src/state/reducers/parentReducer.js
+++ b/src/state/reducers/parentReducer.js
@@ -36,11 +36,9 @@ export const reducer = (state = initialState, action) => {
     case parent.REMOVE_CHILD:
       return {
         ...state,
-        children: state.children.map(child => {
-          if (child.ID !== action.payload) {
-            return child;
-          }
-        }),
+        children: state.children.filter(
+          child => child && child.ID !== action.payload
+        ),
       };
     case global.CLEAR_USERS:
       return initialState;


### PR DESCRIPTION
There were two arrow functions that used the "map" array method when "filter" was more appropriate. This lead to there being no return statement for anything that didn't fit the conditional, which created two respective warnings in the console.

Here is the [trello card](https://trello.com/c/4Y1pqTao/616-other-warnings-and-error-c) related to these warnings.