### PR TITLE
set value in radio button to relevant value

### DIFF
--- a/src/components/pages/WordCloud/index.js
+++ b/src/components/pages/WordCloud/index.js
@@ -27,10 +27,10 @@ function RenderWordCloud() {
           <input
             type="radio"
             name="render"
-            value="Crop Cloud"
+            value={1}
             id="cropcloud"
             className="switcher__input switcher__input--cc"
-            onChange={() => handleButtonPress(1)}
+            onChange={handleButtonPress}
             //checked={cloud === 'cropcloud'}
             defaultChecked={true}
           />


### PR DESCRIPTION
This PR FIXES issue of controlled vs uncontrolled issue of radio button conditional render between Crop Cloud and Word Cloud

Super simple fix in cleaning up the logic. 

The previous value was set to value="Crop Cloud" and on change passing in a value of 1 by way of onChange{() => handleButtonPress(1)} as an argument to the handleButtonPress helper function. As the radio button already has a baked in value that is passed in on change, I changed the value to value={1}  and simply called the function onChange{handleButtonPress}. This alleviated the issue and cleaned up the handling of the functional call

REFERS TO: 

Trello: https://trello.com/c/vComiBMg
