### PR TITLE
Bug/repair warnings for use effect dependencies game play main game play mission use media

### DIFF
--- a/src/components/pages/Animations/AnimationMediaHelper/useMedia.js
+++ b/src/components/pages/Animations/AnimationMediaHelper/useMedia.js
@@ -14,7 +14,7 @@ const useMedia = query => {
     media.addEventListener(Animation, listener);
 
     return () => media.removeEventListener(Animation, listener);
-  }, [query]);
+  }, [query, matches]);
 
   // publish value for render
   return matches;

--- a/src/components/pages/GamePlay/GamePlayMain.js
+++ b/src/components/pages/GamePlay/GamePlayMain.js
@@ -37,7 +37,7 @@ function GamePlayMain(props) {
       <Header />
 
       <Switch>
-        <Route path={baseURL} exact>
+        <Route exact path={baseURL}>
           <GamemodeBtns
             baseURL={baseURL}
             enableModalWindow={enableModalWindow}

--- a/src/components/pages/GamePlay/GamePlayMain.js
+++ b/src/components/pages/GamePlay/GamePlayMain.js
@@ -86,6 +86,7 @@ const GamemodeBtns = props => {
     };
 
     props.enableModalWindow(data);
+    // eslint-disable-next-line
   }, []);
 
   return (

--- a/src/components/pages/GamePlay/GamePlayMission.js
+++ b/src/components/pages/GamePlay/GamePlayMission.js
@@ -89,7 +89,7 @@ export default function GamePlayMission(props) {
     gsap.from('#game-mission', { opacity: 0, y: 100, duration: 1 });
 
     gsap.registerPlugin(ScrollToPlugin);
-  }, []);
+  }, [baseURL, history, submissionData.HasRead]);
 
   console.log(submissionData);
 


### PR DESCRIPTION
In this ticket, I was tasked to resolve several useEffect dependency warnings: 

/src/components/pages/Animations/AnimationMediaHelper/useMedia.js
Line 17:6: React Hook useEffect has a missing dependency: 'matches'

./src/components/pages/Gameification/GameificationMain.js
Line 89:6: React Hook useEffect has a missing dependency: 'props'.

./src/components/pages/Gameification/GameificationMission.js
Line 92:6: React Hook useEffect has missing dependencies: 'baseURL'


In useMedia.js, there was a useEffect that was missing the dependency argument, 'matches', on line 17 that was missing. I added the dependency argument and the warning was resolved.

In GamePlayMission.js, there was a useEffect that was actually missing a dependency list, 'baseURL','history', and 'submissionData.HasRead' on line 92. I added them in and the warning was resolved.

In GamePlayMain.js, there's a component called GamemodeBtns that contains a useEffect with a missing dependency 'Props' that was missing on line 89. In this unique case, the warning is unresolvable. I tried everything I could think of but every solution caused the app to break due to infinite updates

. 1.   I tried de-structuring props and adding individual properties of props. I added props.enableModalWindow and that caused the modal window to be infinitely called.

.2. I tried adding props.baseURL and that caused infinite updates. I added in just props and that caused infinite updates. I also removed the dependency array all together and that caused the app to break.

.3. I tried seeing if the window would be triggered to activate by removing the useEffect entirely and infinite updates.

I looked at the structure of the application up to that component and determined that because there are multiple useEffects in different components that are triggered to fire under delicate circumstances that the only way to make sure that the application runs is to leave the useEffect as is with the empty dependency array. I used  a ES disable comment on line 89 to disable the warning. 

In the same file on line 40, I found a syntax error by accident while looking at the codebase. In the tag of a Route component, there was an "exact" that was in the wrong position. There wasn't any warnings on this but I decided to move it to its proper place in the tag.

Trello card: https://trello.com/c/3xOEtrei/594-useeffect-missing-dependencies-warnings-b

PR submission video: https://drive.google.com/file/d/1xtpgI9CkCb0z9j2X7vwMLJiH_542pj37/view?usp=sharing