### PR TITLE
Bug/repair warnings for thrashbar

### DIFF
--- a/src/components/pages/Gamemode/Thrashbar.jsx
+++ b/src/components/pages/Gamemode/Thrashbar.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Row, Col, Button } from 'antd';
+import { Row, Col } from 'antd';
 import { connect } from 'react-redux';
 
 class Thrashbar extends React.Component {

--- a/src/components/pages/Gamemode/Thrashbar.jsx
+++ b/src/components/pages/Gamemode/Thrashbar.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, Component } from 'react';
+import React from 'react';
 
 import { Row, Col, Button } from 'antd';
 import { connect } from 'react-redux';

--- a/src/state/reducers/galleryReducer.js
+++ b/src/state/reducers/galleryReducer.js
@@ -1,7 +1,7 @@
 import { submissions } from '../actions';
 
 const initialState = {
-feature/update-gallery-reducer-schema
+  //feature/update-gallery-reducer-schema
   WritingUrl: '',
   PageNum: 0,
   DrawingUrl: '',
@@ -19,8 +19,6 @@ feature/update-gallery-reducer-schema
   LowConfidence: false,
   CreatedAt: '',
   UpdatedAt: '',
-
-
 };
 
 export const reducer = (state = initialState, action) => {
@@ -28,7 +26,7 @@ export const reducer = (state = initialState, action) => {
     case submissions.SET_WEEKLY_SUBMISSIONS:
       return {
         ...state,
-       feature/update-gallery-reducer-schema
+        // feature/update-gallery-reducer-schema
         WritingUrl: action.payload.WritingUrl,
         PageNum: action.payload.PageNum,
         DrawingUrl: action.payload.DrawingUrl,


### PR DESCRIPTION
In this ticket, I repaired several defined but never used warnings:

./src/components/pages/Gamemode/Thrashbar.jsx
Line 1:17: 'useState' is defined but never used no-unused-vars
Line 1:27: 'useEffect' is defined but never used no-unused-vars
Line 1:38: 'Component' is defined but never used no-unused-vars
Line 3:20: 'Button' is defined but never used no-unused-vars

./src/components/pages/GamePlay/GamePlayMain.js
Line 3:10: 'connect' is defined but never used

In Thrashbar.jsx, there was a useState,useEffect,and Component import that I removed that were never implemented on #1.  I removed the Button import on #3 because it was never used.

In GamePlayMain, that warning is outdated. Somebody else has implemented connect.

On galleryReducer.js I commented out what I assume where suppose to be comments on #4 and #29. I'm making the assumption that when changes to the reducer were being made, these accidentally slipped through.

Trello card: https://trello.com/c/YoMUWFUK/602-defined-but-never-used-e

PR submission video: https://drive.google.com/file/d/1lyC2sd09PnqdlQRQVwCZJplpGf5WSXWQ/view?usp=sharing

