### PR TITLE
Change avatar page

### DIFF
--- a/src/components/pages/ChangeAvatar/ChangeAvatarContainer.js
+++ b/src/components/pages/ChangeAvatar/ChangeAvatarContainer.js
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { useAuth0 } from '@auth0/auth0-react';
+
+import { connect } from 'react-redux';
+
+import RenderChangeAvatar from './RenderChangeAvatar';
+
+const ChangeAvatarContainer = ({ LoadingComponent, ...props }) => {
+  const { user, isAuthenticated } = useAuth0();
+  const [userInfo] = useState(user);
+
+  return (
+    <>
+      {isAuthenticated && !userInfo && (
+        <LoadingComponent message="Loading..." />
+      )}
+      {isAuthenticated && userInfo && (
+        <RenderChangeAvatar {...props} userInfo={userInfo} />
+      )}
+    </>
+  );
+};
+
+export default connect(
+  state => ({
+    child: state.child,
+    tasks: state.tasks,
+  }),
+  {}
+)(ChangeAvatarContainer);

--- a/src/components/pages/ChangeAvatar/RenderChangeAvatar.js
+++ b/src/components/pages/ChangeAvatar/RenderChangeAvatar.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Header } from '../../common';
+
+const RenderChangeAvatar = () => {
+  return (
+    <>
+      <Header displayMenu={true} />
+    </>
+  );
+};
+
+export default RenderChangeAvatar;

--- a/src/components/pages/ChangeAvatar/index.js
+++ b/src/components/pages/ChangeAvatar/index.js
@@ -1,0 +1,1 @@
+export { default as ChangeAvatar } from './ChangeAvatarContainer.js';

--- a/src/components/pages/ChildDashboard/RenderChildDashboard.js
+++ b/src/components/pages/ChildDashboard/RenderChildDashboard.js
@@ -22,8 +22,8 @@ const RenderChildDashboard = props => {
     push('/child/join');
   };
 
-  const handleAdminPage = event => {
-    push('/admin');
+  const handleChangeAvatar = event => {
+    push('/child/change-avatar');
   };
 
   const handleLeaderboard = e => {
@@ -62,7 +62,7 @@ const RenderChildDashboard = props => {
             className="change-avatar"
             xs={24}
             sm={12}
-            onClick={handleAdminPage}
+            onClick={handleChangeAvatar}
           >
             <img
               className="child-dash-img"

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,7 @@ import { EditPlayers } from './components/pages/EditPlayers';
 import { StoryPrompt } from './components/pages/StoryPrompt';
 import { WritingSub } from './components/pages/WritingSub';
 import { Leaderboard } from './components/pages/Leaderboard';
+import { ChangeAvatar } from './components/pages/ChangeAvatar';
 import FaceoffReveal from './components/pages/Animations/FaceoffReveal';
 
 // GamePlay Components
@@ -273,6 +274,12 @@ function App() {
           path="/child/leaderboard"
           component={() => (
             <Leaderboard LoadingComponent={ChildLoadingComponent} />
+          )}
+        />
+        <ProtectedRoute
+          path="/child/change-avatar"
+          component={() => (
+            <ChangeAvatar LoadingComponent={ChildLoadingComponent} />
           )}
         />
         <ProtectedRoute

--- a/src/styles/less/ChildDashboard.less
+++ b/src/styles/less/ChildDashboard.less
@@ -27,6 +27,7 @@
   .leaderboard {
     border: 5px solid @header-nero;
     height: 35vh;
+    cursor: pointer
   }
 
 
@@ -38,7 +39,6 @@
     background-position: center;
     background-color: @conifer;
     opacity: 75%;
-    cursor: pointer;
 
     img {
       z-index: 1;


### PR DESCRIPTION
This branch adds a page at http://localhost:3000/child/change-avatar
This is important right now because currently, through the child/dashboard route, when you click on the Change Avatar card, it will redirect you to the admin dashboard.

The trello card this relates to [is here](https://trello.com/c/UH9bCPpI/632-child-dashboard-fix-change-avatar-button-create-change-avatar-page)

The page currently only consists of the header:
![image](https://user-images.githubusercontent.com/72050425/137411229-47c211fe-323e-49d2-8c0d-cda852b43497.png)