### PR TITLE
Feature/changing look of singleplayer button gamemeode component

### DIFF
--- a/src/components/pages/Gamemode/Gamemode.js
+++ b/src/components/pages/Gamemode/Gamemode.js
@@ -104,7 +104,7 @@ const Gamemode = ({ ...props }) => {
             <div className="dash-container">
               <Header />
 
-              <Row>
+              <Row className="adventure-passport-container">
                 <Col className="adventure-passport" xs={16} sm={24}>
                   {!sP && props.child.gamemode.mode === 'select' && (
                     <Link to="/gameplay">{trig()}</Link>

--- a/src/components/pages/Gamemode/Gamemode.js
+++ b/src/components/pages/Gamemode/Gamemode.js
@@ -107,7 +107,7 @@ const Gamemode = ({ ...props }) => {
               <Row className="adventure-passport-container">
                 <Col className="adventure-passport" xs={16} sm={24}>
                   {!sP && props.child.gamemode.mode === 'select' && (
-                    <Link to="/gameplay">{trig()}</Link>
+                    <Link to="/gameplay">Single Player</Link>
                   )}
                 </Col>
               </Row>

--- a/src/styles/less/ChildDashboard.less
+++ b/src/styles/less/ChildDashboard.less
@@ -67,7 +67,7 @@
     }
   }
   div.adventure-passport {
-    border-width: .75rem .375rem .75rem .75rem;
+    border-width: .2rem .2rem .2rem .2rem;
     @media @tablet {
       border-width: .5rem .25rem .5rem .5rem;
     }

--- a/src/styles/less/ChildDashboard.less
+++ b/src/styles/less/ChildDashboard.less
@@ -142,6 +142,17 @@
     background: @bright-sun;
     opacity: 75%;
   }
+  
+// Target Link in adventure-passport
+  .adventure-passport a{
+    width:100%;
+    height:100%;
+    color: black;
+    font-size:xx-large;
+    font-family: 'bangers',cursive;
+    padding-top:2%;
+    text-align: center;
+  }
 
   .adventure-passport img {
     max-width: 80%;

--- a/src/styles/less/ChildDashboard.less
+++ b/src/styles/less/ChildDashboard.less
@@ -196,7 +196,8 @@
 
 .adventure-passport:hover {
   opacity: 100%;
-
+  animation: adventure-passport-animation linear 1s;
+  transform: scale(1.03);
   img {
     max-width: 100%;
     max-height: 100%;

--- a/src/styles/less/ChildDashboard.less
+++ b/src/styles/less/ChildDashboard.less
@@ -203,6 +203,16 @@
   }
 }
 
+@keyframes adventure-passport-animation {
+  from {
+    transform: scale(1.0);
+  }
+  to{
+    transform: scale(1.03);
+  }
+  
+}
+
 .trophy-room:hover {
   opacity: 100%;
 

--- a/src/styles/less/ChildDashboard.less
+++ b/src/styles/less/ChildDashboard.less
@@ -197,7 +197,7 @@
 .adventure-passport:hover {
   opacity: 100%;
   animation: adventure-passport-animation linear 1s;
-  transform: scale(1.03);
+  transform: scale(1.01);
   img {
     max-width: 100%;
     max-height: 100%;
@@ -209,7 +209,7 @@
     transform: scale(1.0);
   }
   to{
-    transform: scale(1.03);
+    transform: scale(1.01);
   }
   
 }

--- a/src/styles/less/ChildDashboard.less
+++ b/src/styles/less/ChildDashboard.less
@@ -25,7 +25,7 @@
   .adventure-passport,
   .trophy-room,
   .leaderboard {
-    border: 5px solid @header-nero;
+    border: 2px solid @header-nero;
     height: 35vh;
     cursor: pointer
   }


### PR DESCRIPTION
In this ticket, I changed the look of the single player component of gamemode component.

Reason for change:
The previous look was basically just a container with a little button at the center which was the link to start single player mode. It didn't look great and it didn't match the look and feel of the other buttons.

Changes made:
I changed the thickness of the border around the container. I made it thinner so it wasn't as pronounced.

I added an animation to slightly scale the container when hovering over it with the cursor. I got rid of the function call that called a function named trig that would render a button component when firing. Instead I replaced the call with the text Single Player. Increased the width and height of the Link component to cover the entire container so that no matter where you clicked in the container it would route you to the next appropriate component.

I added a class name to the container of the link so that in the future when we add more buttons for different gameplay modes we can easily target them with css.

I added coloring, font size and font family to match the styling of the text of the other gameplay buttons in gameplaymain component. I then added some padding to the padding-top property so that the text within the button was pushed down slightly.

Note: when traversing the code base, I tested the GamemodeButton component. I'm 100 percent sure that this is an outdated component that is no longer being used. I believe that this component and the path to this component should be deleted. I didn't do it because that's not what the purpose of this branch was. My submission video has a more visual and detailed explanation to justify my case.

Trello Card: https://trello.com/c/MBKHEPCK/642-import-gameplaymain-from-components-pages-gameplay-index

PR submission video: https://drive.google.com/file/d/1CYO6wsE-7Sz5_kv6UGBYP0vD63gN8c5r/view?usp=sharing