### PR TITLE
Bug/remove duplicate routes

### DIFF
--- a/src/components/common/ParentDashboardBack.js
+++ b/src/components/common/ParentDashboardBack.js
@@ -6,7 +6,7 @@ import { useHistory } from 'react-router-dom';
 const ParentDashboardBack = props => {
   const history = useHistory();
   const backButton = () => {
-    history.push('/parent/dashboard');
+    history.push('/');
   };
   return (
     <Button

--- a/src/components/common/ParentNavSider.js
+++ b/src/components/common/ParentNavSider.js
@@ -28,7 +28,7 @@ const ParentNavSider = props => {
         defaultSelectedKeys={[props.selected]}
       >
         <Menu.Item key="dashboard">
-          <Link to="/parent/dashboard">Dashboard</Link>
+          <Link to="/">Dashboard</Link>
         </Menu.Item>
         <Menu.Item key="settings">
           <Link to="/parent/settings">Parent Settings</Link>

--- a/src/components/common/ParentNavTopBar.js
+++ b/src/components/common/ParentNavTopBar.js
@@ -37,7 +37,7 @@ const ParentMenu = props => {
 const ParentNavTopBar = props => {
   return (
     <nav className="parent-nav-top-bar" theme="light">
-      <Link to="/parent/dashboard">
+      <Link to="/">
         <Title className="title navbar-logo" level={1}>
           STORY SQUAD
         </Title>

--- a/src/components/common/ParentNavTopBar.js
+++ b/src/components/common/ParentNavTopBar.js
@@ -64,7 +64,7 @@ const ParentNavTopBar = props => {
           placement="bottomCenter"
         >
           <a
-            href="/parent/dashboard"
+            href="/"
             className="parent-avatar"
             data-testid="parent-avatar"
             onClick={e => e.preventDefault()}

--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,13 @@ function App() {
         <Route path="/gameplay" component={GamePlayMain} />
         <Route path="/login" component={LandingPage} />
         {/* any of the routes you need secured should be registered as ProtectedRoutes */}
-
+        <ProtectedRoute
+          exact
+          path="/parent/dashboard"
+          component={() => (
+            <NewParentDashboard LoadingComponent={ParentLoadingComponent} />
+          )}
+        />
         <ProtectedRoute
           path="/child/story"
           component={() => (
@@ -183,13 +189,6 @@ function App() {
           path="/parent/edit-players"
           component={() => (
             <EditPlayers LoadingComponent={ParentLoadingComponent} />
-          )}
-        />
-        <ProtectedRoute
-          exact
-          path="/parent/dashboard"
-          component={() => (
-            <NewParentDashboard LoadingComponent={ParentLoadingComponent} />
           )}
         />
 

--- a/src/index.js
+++ b/src/index.js
@@ -195,13 +195,6 @@ function App() {
 
         <ProtectedRoute
           exact
-          path="/parent/dashboard-faq"
-          component={() => (
-            <ParentDashFaq LoadingComponent={ParentLoadingComponent} />
-          )}
-        />
-        <ProtectedRoute
-          exact
           path="/parent/support"
           component={() => (
             <SupportPage LoadingComponent={ParentLoadingComponent} />

--- a/src/index.js
+++ b/src/index.js
@@ -114,13 +114,7 @@ function App() {
         <Route path="/gameplay" component={GamePlayMain} />
         <Route path="/login" component={LandingPage} />
         {/* any of the routes you need secured should be registered as ProtectedRoutes */}
-        <ProtectedRoute
-          exact
-          path="/"
-          component={() => (
-            <NewParentDashboard LoadingComponent={ParentLoadingComponent} />
-          )}
-        />
+
         <ProtectedRoute
           path="/child/story"
           component={() => (

--- a/src/index.js
+++ b/src/index.js
@@ -116,11 +116,12 @@ function App() {
         {/* any of the routes you need secured should be registered as ProtectedRoutes */}
         <ProtectedRoute
           exact
-          path="/parent/dashboard"
+          path="/"
           component={() => (
             <NewParentDashboard LoadingComponent={ParentLoadingComponent} />
           )}
         />
+
         <ProtectedRoute
           path="/child/story"
           component={() => (


### PR DESCRIPTION
In this ticket, I removed a duplicate Protected Route component from src/index.js:

There were two Protected Route components that were meant to render the Parent Dashboard. There was nothing to this I just removed the duplicate. The first Protected Route had the path "/ " and the second had the path "/parent/dashboard". I deleted the second component.

Motivation:
This task was just meant to clean up the routing.

Trello card: https://trello.com/c/ZLfeRrNm/662-parentdashboard-fix-bug-related-to-protectedroutes

PR submission: https://drive.google.com/file/d/1KoSccsp2XspwFpg_8Y_DbKMoelqkkBbq/view?usp=sharing