### PR TITLE
Find and Link Trophy Room - Change page to UNDER CONSTRUCTION temporarily 

### DIFF
--- a/src/components/pages/GamePlay/GamePlayMain.js
+++ b/src/components/pages/GamePlay/GamePlayMain.js
@@ -9,6 +9,7 @@ import { Header } from '../../common';
 import { NotFoundPage } from '../NotFound';
 import Footer from './Footer';
 import GamePlayMission from './GamePlayMission';
+import { TrophyRoom } from '../TrophyRoom/index';
 import GameModal from './GameModal';
 
 function GamePlayMain(props) {
@@ -51,6 +52,13 @@ function GamePlayMain(props) {
             disableModalWindow={disableModalWindow}
           />
         </Route>
+        <Route path={`${baseURL}/`}>
+          <TrophyRoom
+            baseURL={baseURL}
+            enableModalWindow={enableModalWindow}
+            disableModalWindow={disableModalWindow}
+          />
+        </Route>
 
         <Route component={NotFoundPage} />
       </Switch>
@@ -73,7 +81,6 @@ const GamemodeBtns = props => {
 
   const acceptMission = e => {
     e.preventDefault();
-
     history.push(`${props.baseURL}/mission/read`);
   };
 

--- a/src/components/pages/GamePlay/GamePlayMain.js
+++ b/src/components/pages/GamePlay/GamePlayMain.js
@@ -108,9 +108,7 @@ const GamemodeBtns = props => {
           Accept The Mission
         </button>
 
-        <button className="" onClick={trophyRoom}>
-          Trophy Room
-        </button>
+        <button onClick={trophyRoom}>Trophy Room</button>
       </div>
     </div>
   );

--- a/src/components/pages/GamePlay/GamePlayMain.js
+++ b/src/components/pages/GamePlay/GamePlayMain.js
@@ -77,6 +77,11 @@ const GamemodeBtns = props => {
     history.push(`${props.baseURL}/mission/read`);
   };
 
+  const trophyRoom = e => {
+    e.preventDefault();
+    history.push(`${props.baseURL}/trophy-room`);
+  };
+
   // Enable initial modal
   useEffect(() => {
     const data = {
@@ -96,7 +101,9 @@ const GamemodeBtns = props => {
           Accept The Mission
         </button>
 
-        <button>Trophy Room</button>
+        <button className="" onClick={trophyRoom}>
+          Trophy Room
+        </button>
       </div>
     </div>
   );

--- a/src/components/pages/TrophyRoom/RenderTrophyRoom.js
+++ b/src/components/pages/TrophyRoom/RenderTrophyRoom.js
@@ -1,77 +1,112 @@
-import React, { useState } from 'react';
-import { Header } from '../../common';
-import Leaderboard from './Leaderboard';
+//TEMPORARY - THIS COMPONENT IS NOW RENDERING AND UNDER CONSTRUCTION
+// As we are deciding direction on the component all commented out code sections that were are unsure from the original iteration will be labeled as TEMPORARY
+
+import React from 'react';
+
+// TEMPORARY
+// import { Header } from '../../common';
+// import Leaderboard from './Leaderboard';
 
 import { connect } from 'react-redux';
 
-import { Divider, Button, Modal } from 'antd';
+//TEMPORARY - Removed modal and divider as unused while we are working on the trophy room
+import { Button } from 'antd';
 import { useHistory } from 'react-router-dom';
-import { child } from '../../../state/actions';
+
+// TEMPORARY
+// import { child } from '../../../state/actions';
 
 const RenderLeaderboard = props => {
   const { push } = useHistory();
-  const [isAchievementModalVisible, setIsAchievementModalVisible] = useState(
-    false
-  );
-  const [isInventoryModalVisible, setIsInventoryModalVisible] = useState(false);
-  const [inventoryState, setInventoryState] = useState('');
-  const [achievementState, setAchievementState] = useState('');
-  const [streakState, setStreakState] = useState('');
-  const [isStreakModalVisible, setIsStreakModalVisible] = useState(false);
+
+  // TEMPORARY
+  // const [isAchievementModalVisible, setIsAchievementModalVisible] = useState(
+  //   false
+  // );
+  // const [isInventoryModalVisible, setIsInventoryModalVisible] = useState(false);
+  // const [inventoryState, setInventoryState] = useState('');
+  // const [achievementState, setAchievementState] = useState('');
+  // const [streakState, setStreakState] = useState('');
+  // const [isStreakModalVisible, setIsStreakModalVisible] = useState(false);
 
   const dashboard = () => {
-    push('/child/dashboard');
+    push('/gameplay');
   };
 
-  const showAchievementsModal = () => {
-    setIsAchievementModalVisible(true);
-    setAchievementState('child.achievements');
-  };
+  // TEMPORARY
+  // const showAchievementsModal = () => {
+  //   setIsAchievementModalVisible(true);
+  //   setAchievementState('child.achievements');
+  // };
 
-  const showInventoryModel = () => {
-    setIsInventoryModalVisible(true);
-    setInventoryState('child.inventory');
-  };
+  // const showInventoryModel = () => {
+  //   setIsInventoryModalVisible(true);
+  //   setInventoryState('child.inventory');
+  // };
 
-  const handleAchievmentOk = () => {
-    setIsAchievementModalVisible(false);
-  };
+  // const handleAchievmentOk = () => {
+  //   setIsAchievementModalVisible(false);
+  // };
 
-  const handleAchievementCancel = () => {
-    setIsAchievementModalVisible(false);
-  };
+  // const handleAchievementCancel = () => {
+  //   setIsAchievementModalVisible(false);
+  // };
 
-  const handleInventoryOk = () => {
-    setIsInventoryModalVisible(false);
-  };
+  // const handleInventoryOk = () => {
+  //   setIsInventoryModalVisible(false);
+  // };
 
-  const handleInventoryCancel = () => {
-    setIsInventoryModalVisible(false);
-  };
+  // const handleInventoryCancel = () => {
+  //   setIsInventoryModalVisible(false);
+  // };
 
-  const handleStreakOk = () => {
-    setIsStreakModalVisible(false);
-  };
+  // const handleStreakOk = () => {
+  //   setIsStreakModalVisible(false);
+  // };
 
-  const handleStreakCancel = () => {
-    setIsStreakModalVisible(false);
-  };
+  // const handleStreakCancel = () => {
+  //   setIsStreakModalVisible(false);
+  // };
 
-  const showStreakModel = () => {
-    setIsStreakModalVisible(true);
-    setStreakState('child.streak');
-  };
+  // const showStreakModel = () => {
+  //   setIsStreakModalVisible(true);
+  //   setStreakState('child.streak');
+  // };
 
   return (
     <>
-      <Header displayMenu={true} title="STORY SQUAD" />
-      <Button
-        style={{ margin: '1rem' }}
-        className="back-btn"
-        onClick={dashboard}
-      >
-        Back to Child Dashboard
-      </Button>
+      {/* TEMPORARY  BELOW SECTION IS THE UNDER CONSTRUCTION SECTION TO BE REMOVED WHEN FUNCTIONAL PAGE IS READY TO BE USED*/}
+      <div className={'under-construction'}>
+        <div className={'rectangle-126'}>
+          <h1>Coming Soon</h1>
+        </div>
+        <div className={'under-construction-content'}>
+          <h1>Under Construction!</h1>
+          <h1>Trophy Room UI Coming Soon!</h1>
+        </div>{' '}
+        <Button
+          style={{ margin: '1rem' }}
+          className="back-btn"
+          onClick={dashboard}
+        >
+          {' '}
+          Back to Gameplay{' '}
+        </Button>
+      </div>
+      {/* ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  TEMPORARY UNDER CONSTRUCTION SECTION ABOVE TO BE REMOVED*/}
+
+      {/* TEMPORARY  */}
+      {/* <h1>Coming Soon</h1>
+       <Header displayMenu={true} title="STORY SQUAD" />
+       <Button
+          style={{ margin: '1rem' }}
+          className="back-btn"
+          onClick={dashboard}
+        >
+          {' '}
+          Back to Child Dashboard
+        </Button>
+  
       <div className="trophy-container">
         <Leaderboard child={props.child} />
         <div className="custom-divider"></div>
@@ -87,13 +122,17 @@ const RenderLeaderboard = props => {
             // width={900}
           >
             <div style={{ overflow: 'scroll' }}>
-              <h3>Completed (Way to go!):</h3>
-              {/* {achievementState.map(achievement => {
+              <h3>Completed (Way to go!):</h3> */}
+
+      {/* TEMPORARY  THIS SECTION WAS PREVIOUSLY COMMENTED OUT AWAITING DATA*/}
+      {/* {achievementState.map(achievement => {
             if (achievement.completed === true) {
               return <p>{achievement}</p>;
             }
           })} */}
-              <p>Completed first Mission!</p>
+
+      {/* TEMPORARY */}
+      {/* <p>Completed first Mission!</p>
               <p>Won a game!</p>
               <p>Got most points for drawing in a mission!</p>
               <p>Got most points for writing in a mission!</p>
@@ -101,17 +140,21 @@ const RenderLeaderboard = props => {
               <h3>Incomplete (Keep trying!):</h3>
               <p>Completed 5 missions in a row!</p>
               <p>Completed 10 Missions in a row!</p>
-              <p>Most Colorful Drawing</p>
-              {/* {achievementState.map(achievement => {
+              <p>Most Colorful Drawing</p> */}
+
+      {/* TEMPORARY  THIS SECTION WAS PREVIOUSLY COMMENTED OUT AWAITING DATA*/}
+      {/* {achievementState.map(achievement => {
             if (achievement.completed === false) {
               return <p>{achievement}</p>;
             }
           })} */}
-            </div>
-          </Modal>
-          <Divider />
-          {/* Add this to Change Your Avatar once it is implemented */}
-          <h2 className="h2" onClick={showInventoryModel}>
+
+      {/* TEMPORARY */}
+      {/* </div> */}
+      {/* </Modal>
+          <Divider /> */}
+      {/* Add this to Change Your Avatar once it is implemented */}
+      {/* <h2 className="h2" onClick={showInventoryModel}>
             Inventory
           </h2>
           <Modal
@@ -123,9 +166,9 @@ const RenderLeaderboard = props => {
           >
             <h3>Skins</h3>
             <h3>Stickers</h3>
-            <h3>Collectibles</h3>
-            {/* Map over inventory state here */}
-          </Modal>
+            <h3>Collectibles</h3> */}
+      {/* Map over inventory state here */}
+      {/* </Modal>
           <Divider />
           <h2 className="h2" onClick={showStreakModel}>
             Current Streak
@@ -139,9 +182,9 @@ const RenderLeaderboard = props => {
           >
             <h3>
               {`Your current login streak is ${child.Streaks} weeks! Keep up the great work!`}
-            </h3>
-            {/* get child.streak from the child db */}
-            <img src={require('./greatjob.gif')} alt="Great job!" />
+            </h3> */}
+      {/* get child.streak from the child db */}
+      {/* <img src={require('./greatjob.gif')} alt="Great job!" />
           </Modal>
         </div>
       </div>
@@ -153,7 +196,7 @@ const RenderLeaderboard = props => {
         >
           Back to Child Dashboard
         </Button>
-      </div>
+      </div>  */}
     </>
   );
 };

--- a/src/components/pages/TrophyRoom/TrophyRoomContainer.js
+++ b/src/components/pages/TrophyRoom/TrophyRoomContainer.js
@@ -17,7 +17,7 @@ const TrophyRoomContainer = ({ LoadingComponent, ...props }) => {
         <RenderTrophyRoom
           {...props}
           userInfo={userInfo}
-          authService={authService}
+          // authService={authService}
         />
       )}
     </>

--- a/src/styles/less/TrophyRoom.less
+++ b/src/styles/less/TrophyRoom.less
@@ -122,8 +122,8 @@
 //   filter: drop-shadow($size-shadow-large $gray);
 // }
 .ant-modal-title {
-  color: #FF9100;
-  text-shadow: -4px 0 #FFFFFF, 0 4px #FFFFFF, 4px 0 #FFFFFF, 0 -4px #FFFFFF;
+  color: #ff9100;
+  text-shadow: -4px 0 #ffffff, 0 4px #ffffff, 4px 0 #ffffff, 0 -4px #ffffff;
   text-align: center;
   font-size: 3rem;
   font-family: 'bangers';
@@ -132,8 +132,8 @@
   letter-spacing: 7px;
 }
 .ant-modal-body h3 {
-  color: #FF9100;
-  text-shadow: -4px 0 #FFFFFF, 0 4px #FFFFFF, 4px 0 #FFFFFF, 0 -4px #FFFFFF;
+  color: #ff9100;
+  text-shadow: -4px 0 #ffffff, 0 4px #ffffff, 4px 0 #ffffff, 0 -4px #ffffff;
   font-size: 2rem;
   font-family: 'bangers';
   font-weight: bold;
@@ -142,8 +142,8 @@
   text-align: center;
 }
 .ant-modal-body p {
-  color: #939AFF;
-  text-shadow: -4px 0 #FFFFFF, 0 4px #FFFFFF, 4px 0 #FFFFFF, 0 -4px #FFFFFF;
+  color: #939aff;
+  text-shadow: -4px 0 #ffffff, 0 4px #ffffff, 4px 0 #ffffff, 0 -4px #ffffff;
   font-size: 1rem;
   font-family: 'bangers';
   letter-spacing: 1px;
@@ -177,8 +177,8 @@
   }
 }
 .ant-modal-title {
-  color: #FF9100;
-  text-shadow: -4px 0 #FFFFFF, 0 4px #FFFFFF, 4px 0 #FFFFFF, 0 -4px #FFFFFF;
+  color: #ff9100;
+  text-shadow: -4px 0 #ffffff, 0 4px #ffffff, 4px 0 #ffffff, 0 -4px #ffffff;
   text-align: center;
   font-size: 3rem;
   font-family: 'bangers';
@@ -187,8 +187,8 @@
   letter-spacing: 7px;
 }
 .ant-modal-body h3 {
-  color: #FF9100;
-  text-shadow: -4px 0 #FFFFFF, 0 4px #FFFFFF, 4px 0 #FFFFFF, 0 -4px #FFFFFF;
+  color: #ff9100;
+  text-shadow: -4px 0 #ffffff, 0 4px #ffffff, 4px 0 #ffffff, 0 -4px #ffffff;
   font-size: 2rem;
   font-family: 'bangers';
   font-weight: bold;
@@ -197,8 +197,8 @@
   text-align: center;
 }
 .ant-modal-body p {
-  color: #939AFF;
-  text-shadow: -4px 0 #FFFFFF, 0 4px #FFFFFF, 4px 0 #FFFFFF, 0 -4px #FFFFFF;
+  color: #939aff;
+  text-shadow: -4px 0 #ffffff, 0 4px #ffffff, 4px 0 #ffffff, 0 -4px #ffffff;
   font-size: 1rem;
   font-family: 'bangers';
   letter-spacing: 1px;
@@ -208,3 +208,60 @@
 .parent {
   border: 2px solid red;
 }
+
+
+// ALL TEMPORARY STYLE TO BE REMOVED WHEN CONSTRUCTION IS FINISHED
+.under-construction {
+  height: 40rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 10vh;
+}
+
+.rectangle-126 {
+  width: 872.62px;
+  height: 116.19px;
+  left: 30;
+  top: 35;
+  z-index: -1;
+  background: #2d2a2b;
+  transform: matrix(1, -0.01, 0.07, 1, 0, 0);
+  color: white;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.rectangle-126 h1 {
+  font-size: 3rem;
+  font-family: 'atma';
+  font-weight: bold;
+  letter-spacing: 7px;
+  color: white;
+  padding-top: 15px;
+}
+
+.back-btn {
+  width: auto;
+  height: auto !important;
+  background-color: #ff9100 !important;
+  color: #fff !important;
+  font-family: 'atma';
+  font-size: 2rem !important;
+}
+
+.under-construction-content {
+  color: white;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  font-size: 2rem;
+  font-family: 'atma';
+  font-weight: bold;
+  letter-spacing: 7px;
+  margin: auto 10vh;
+}
+


### PR DESCRIPTION
This PR is meant to fix the non working status of the trophy room button on /gamplay path

In looking through the code I found an iteration of a trophy page with comprehensive logic in it not tied to anything. I went ahead and linked it to the Button adding an event handler to push the user to the props.baseURL/gameplay/trophy-room and called that function on click utilizing the existing button element contained in GamePlayMain.js. I created a route utilizing the same switch statement space that the gameplay mission route was in along with the 404 not found message, and GameModeBtns. 

After getting the existing RenderTrophyRoom component to be visible i was able to view the rendered elements that were not tied to data yet.  As I unsure of the future usage of the existing code, I commented out all that was not needed and replaced it with TEMPORARY labels noting what each was for. Prior commented out .maps waiting for data and imports that were unused were labeled as such. 

Each area that was adjusted was labeled for future devs to finish. 

I also added some temporary styling to make the new under construction elements match the figma design. To ensure that any future user did not get stuck in the under construction page I created a button matching the style of the rest of the page and utilizing the atma font. 

This page is now functioning as currently intended with clean navigation to and from. 

RERFERENCING  Trello Card: https://trello.com/c/NpuFouxI

PR VIDEO: https://youtu.be/x43RFktKxmU