### PR TITLE
Bugs/components/pages/parent faq

### DIFF
--- a/src/components/pages/ParentFaq/ParentFaqContainer.js
+++ b/src/components/pages/ParentFaq/ParentFaqContainer.js
@@ -19,9 +19,9 @@ const ParentFaqContainer = () => {
           <Row className="card">
             <Col span={16} className="col-btn">
               <Row>
-                <h4 style={{ color: '#878D93', fontWeight: '700' }}>
+                <h3 style={{ color: '#878D93', fontWeight: '700' }}>
                   FREQUENTLY ASKED QUESTIONS
-                </h4>
+                </h3>
               </Row>
               <div className="btn-group">
                 <Row>

--- a/src/styles/less/ParentDashFaq.less
+++ b/src/styles/less/ParentDashFaq.less
@@ -7,6 +7,7 @@
 }
 
 .container-parent-faq {
+  
   margin-bottom: 24px;
   overflow: hidden;
   min-height: 60vh;

--- a/src/styles/less/ParentFaq.less
+++ b/src/styles/less/ParentFaq.less
@@ -9,18 +9,31 @@
 .parent-back-button {
   .parent-back-button();
 }
+.site-card-border-less-wrapper{
+  display: flex;
+  justify-content: center;
+}
 
-.card {
+.ant-card.card {
   width: 66%;
   background-color: #fbfbfb;
   position: relative;
   margin: 25px auto;
   padding: 20px;
-  border-radius: 16px;
+  border-radius: 1.5%;
   font-size: 24px;
   font-family: sans-serif;
   font-weight: 600;
   color: #2d2a2b;
+  
+}
+
+
+.ant-card-head{
+  display: flex;
+  justify-content: center;
+  border-radius: 1.5%;
+
 }
 .ant-card-head-title {
   font-size: 24px;
@@ -39,6 +52,8 @@
   font-family: sans-serif;
   color: #2d2a2b;
   padding: 5px;
+  
+  
 }
 
 .btn-group {
@@ -80,3 +95,4 @@
     }
   }
 }
+


### PR DESCRIPTION

## Description

Add a summary that address the following:

-With this ticket I updated the styling on the Parent FAQ page. All of the contents regarding the the question and answer cards were shifted to the left. I created .ant-card.card and removed the .card because the ,card was not selecting all of the cards contains. Once I did this I was able to adjust the border-radius to match the faq container above. I also created .site-card-border-less-wrapper in order to center the cards to the middle of the screen.

## Commits Checklist

- [x] added .site-card-border-less-wrapper to move center content.
- [x] removed extra spacing
- [x] changed the h4 tag to h3 so the font would be bigger

## Code Checklist

[x] Adjust padding for first question of each subsection

[x] Center the Game Play + Content container

https://trello.com/c/Dpgxdm3d/647-import-parentfaq-from-components-pages-parentfaq