### PR TITLE
Feature/ Add Play Again page

### DIFF
--- a/src/components/pages/PlayAgain/PlayAgainContainer.js
+++ b/src/components/pages/PlayAgain/PlayAgainContainer.js
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import { useAuth0 } from '@auth0/auth0-react';
+import { connect } from 'react-redux';
+import RenderPlayAgain from './RenderPlayAgain';
+
+const PlayAgainContainer = ({ LoadingComponent, ...props }) => {
+  const { user, isAuthenticated } = useAuth0();
+  const [userInfo] = useState(user);
+
+  return (
+    <>
+      {isAuthenticated && !userInfo && (
+        <LoadingComponent message="Loading..." />
+      )}
+      {isAuthenticated && userInfo && (
+        <RenderPlayAgain {...props} userInfo={userInfo} />
+      )}
+    </>
+  );
+};
+
+export default connect(
+  state => ({
+    child: state.child,
+    tasks: state.tasks,
+  }),
+  {}
+)(PlayAgainContainer);

--- a/src/components/pages/PlayAgain/RenderPlayAgain.js
+++ b/src/components/pages/PlayAgain/RenderPlayAgain.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Header } from '../../common';
+import { Button } from 'antd';
+import { useHistory } from 'react-router-dom';
+import { connect } from 'react-redux';
+
+const RenderPlayAgain = () => {
+  const { push } = useHistory();
+
+  const goToChildDashboard = () => {
+    push('/child/dashboard');
+  };
+
+  return (
+    <>
+      <Header displayMenu={true} />
+      {/* REMOVE ONCE DESIGN WORK BEGINS - START */}
+      <div className={'under-construction'}>
+        <div className={'rectangle-126'} style={{ margin: '3rem' }}>
+          <h1>Coming Soon</h1>
+        </div>
+        <div className={'under-construction-content'}>
+          <h1>Under Construction!</h1>
+          <h1>Play Again UI Coming Soon!</h1>
+        </div>
+        <Button
+          style={{ margin: '1rem' }}
+          className="back-btn"
+          onClick={goToChildDashboard}
+        >
+          Back to Child Dashboard
+        </Button>
+      </div>
+      {/* REMOVE ONCE DESIGN WORK BEGINS - END */}
+    </>
+  );
+};
+
+export default connect(
+  state => ({
+    child: state.child,
+    tasks: state.tasks,
+  }),
+  {}
+)(RenderPlayAgain);

--- a/src/components/pages/PlayAgain/index.js
+++ b/src/components/pages/PlayAgain/index.js
@@ -1,0 +1,1 @@
+export { default as PlayAgain } from './PlayAgainContainer.js';

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,7 @@ import { GamePlayMain } from './components/pages/GamePlay/index';
 import { PointShare } from './components/pages/PointShare';
 import { MatchUp } from './components/pages/MatchUp';
 import { VotingPage } from './components/pages/VotingPage';
+import { PlayAgain } from './components/pages/PlayAgain';
 
 // Note: for demo/developer purposes ONLY
 import ModerationTest from './components/pages/ModerationTest/ModerationTest';
@@ -251,6 +252,13 @@ function App() {
           path="/child/audiobook"
           component={() => (
             <AudioBook LoadingComponent={ChildLoadingComponent} />
+          )}
+        />
+        <ProtectedRoute
+          exact
+          path="/child/play-again"
+          component={() => (
+            <PlayAgain LoadingComponent={ChildLoadingComponent} />
           )}
         />
         <Route exact path="/moderation" component={ModerationTest} />


### PR DESCRIPTION
This PR is part of a larger route audit.  It will add a Play Again page to the child gameplay UI.  

- add path = /child/play-again to index.js
- add template page and styling to the component
- add folder PlayAgain to the file tree with files:  index.js, PlayAgainContainer.js, RenderPlayAgain.js