### PR TITLE
Feature/move child dashboard to gameplay dashboard route

### DIFF
--- a/src/components/common/ParentNavTopBar.js
+++ b/src/components/common/ParentNavTopBar.js
@@ -44,7 +44,7 @@ const ParentNavTopBar = props => {
       </Link>
       <div className="nav-right">
         <div className="link-container">
-          <Link to="/gamemode">
+          <Link to="/dashboard">
             <Button className="play-game-btn">PLAY GAME</Button>
           </Link>
           <Link to="/parent/faq">

--- a/src/components/pages/ChildDashboard/ChildDashboardContainer.js
+++ b/src/components/pages/ChildDashboard/ChildDashboardContainer.js
@@ -8,11 +8,12 @@ import RenderChildDashboard from './RenderChildDashboard';
 const ChildDashboardContainer = ({ LoadingComponent, ...props }) => {
   const { user, isAuthenticated } = useAuth0();
   const [userInfo] = useState(user);
+  console.log('>>>>>>>>>>>>>>>>>>>>>>>>> userInfo:', userInfo);
 
   return (
     <>
       {isAuthenticated && !userInfo && (
-        <LoadingComponent message="Loading..." />
+        <LoadingComponent message="Checking..." />
       )}
       {isAuthenticated && userInfo && (
         <RenderChildDashboard {...props} userInfo={userInfo} />

--- a/src/components/pages/ChildDashboard/ChildDashboardContainer.js
+++ b/src/components/pages/ChildDashboard/ChildDashboardContainer.js
@@ -8,12 +8,11 @@ import RenderChildDashboard from './RenderChildDashboard';
 const ChildDashboardContainer = ({ LoadingComponent, ...props }) => {
   const { user, isAuthenticated } = useAuth0();
   const [userInfo] = useState(user);
-  console.log('>>>>>>>>>>>>>>>>>>>>>>>>> userInfo:', userInfo);
 
   return (
     <>
       {isAuthenticated && !userInfo && (
-        <LoadingComponent message="Checking..." />
+        <LoadingComponent message="Loading..." />
       )}
       {isAuthenticated && userInfo && (
         <RenderChildDashboard {...props} userInfo={userInfo} />

--- a/src/components/pages/ChildDashboard/RenderChildDashboard.js
+++ b/src/components/pages/ChildDashboard/RenderChildDashboard.js
@@ -15,7 +15,7 @@ const RenderChildDashboard = props => {
   const [modalVisible, setModalVisible] = useState(false);
 
   const handleAcceptMission = e => {
-    push('/child/mission-control');
+    push('/gameplay/mission/read');
   };
 
   const handleJoinSquad = e => {
@@ -27,7 +27,7 @@ const RenderChildDashboard = props => {
   };
 
   const handleLeaderboard = e => {
-    push('/child/leaderboard');
+    push('/gameplay/trophy-room');
   };
 
   return (

--- a/src/components/pages/TrophyRoom/RenderTrophyRoom.js
+++ b/src/components/pages/TrophyRoom/RenderTrophyRoom.js
@@ -30,7 +30,7 @@ const RenderLeaderboard = props => {
   // const [isStreakModalVisible, setIsStreakModalVisible] = useState(false);
 
   const dashboard = () => {
-    push('/gameplay');
+    push('/dashboard');
   };
 
   // TEMPORARY
@@ -90,7 +90,7 @@ const RenderLeaderboard = props => {
           onClick={dashboard}
         >
           {' '}
-          Back to Gameplay{' '}
+          Back to Dashboard{' '}
         </Button>
       </div>
       {/* ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  TEMPORARY UNDER CONSTRUCTION SECTION ABOVE TO BE REMOVED*/}

--- a/src/components/pages/TrophyRoom/TrophyRoomContainer.js
+++ b/src/components/pages/TrophyRoom/TrophyRoomContainer.js
@@ -11,7 +11,8 @@ const TrophyRoomContainer = ({ LoadingComponent, ...props }) => {
   return (
     <>
       {isAuthenticated && !userInfo && (
-        <LoadingComponent message="Loading..." />
+        <h1>Loading</h1>
+        // <LoadingComponent message="Loading..." />
       )}
       {isAuthenticated && userInfo && (
         <RenderTrophyRoom

--- a/src/components/pages/TrophyRoom/TrophyRoomContainer.js
+++ b/src/components/pages/TrophyRoom/TrophyRoomContainer.js
@@ -11,14 +11,14 @@ const TrophyRoomContainer = ({ LoadingComponent, ...props }) => {
   return (
     <>
       {isAuthenticated && !userInfo && (
-        <h1>Loading</h1>
-        // <LoadingComponent message="Loading..." />
+        <LoadingComponent message="Loading..." />
       )}
       {isAuthenticated && userInfo && (
         <RenderTrophyRoom
           {...props}
           userInfo={userInfo}
-          // authService={authService}
+          // Currently not used. Will be used in the future
+          //authService={authService}
         />
       )}
     </>

--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,7 @@ function App() {
         />
 
         <ProtectedRoute
-          path="/child/dashboard"
+          path="/dashboard"
           component={() => (
             <ChildDashboard LoadingComponent={ChildLoadingComponent} />
           )}


### PR DESCRIPTION
This PR moved the component located at child/dashboard to the /dashboard path

The reason for this was to place the already completed component into the proper user flow and and connects the new childs dashboard into the space after parent presses the Play Game button and Chooses the child they are handing to. This dashboard is where the child accepts the device and begins their game play flow.

Needed Next - Under construction place holders for Change Avatar (rendering header only) and Join (404 currently) buttons. Accept Mission is temporarily tied to gameplay/mission/read as the first step of asset submission. gamemode page to be inserted between accept mission button and gameplay/mission/read path

PR VIdeo: https://youtu.be/6LGn5ab58qY