### PR TITLE
Find and Re-wire Match-up page for under construction

### DIFF
--- a/src/components/pages/MatchUp/MatchUpContainer.js
+++ b/src/components/pages/MatchUp/MatchUpContainer.js
@@ -17,51 +17,57 @@ function MatchUpContainer({ LoadingComponent, ...props }) {
   const [userInfo] = useState(user);
   const [canVote, setCanVote] = useState(true);
 
-  useEffect(() => {
-    getChild(user, props.child.id).then(child => {
-      props.setChild({ ...child });
-    });
+  // useEffect(() => {
+  //   getChild(user, props.child.id).then(child => {
+  //     props.setChild({ ...child });
+  //   });
 
-    if (props.child.Ballots) {
-      if (props.child.Ballots.length > 0 && props.child.VotesRemaining > 0) {
-        for (let ballot of props.child.Ballots) {
-          getFaceoffsForVoting(user, ballot[1]).then(faceoffs => {
-            if (props.votes.length === 0) {
-              for (let faceoff of faceoffs) {
-                if (faceoff.ID === ballot[0]) {
-                  props.setVotes(faceoff);
-                }
-              }
-            }
-          });
-        }
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.faceoffs, user, props.child.VotesRemaining]);
+  //   if (props.child.Ballots) {
+  //     if (props.child.Ballots.length > 0 && props.child.VotesRemaining > 0) {
+  //       for (let ballot of props.child.Ballots) {
+  //         getFaceoffsForVoting(user, ballot[1]).then(faceoffs => {
+  //           if (props.votes.length === 0) {
+  //             for (let faceoff of faceoffs) {
+  //               if (faceoff.ID === ballot[0]) {
+  //                 props.setVotes(faceoff);
+  //               }
+  //             }
+  //           }
+  //         });
+  //       }
+  //     }
+  //   }
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, [props.faceoffs, user, props.child.VotesRemaining]);
 
-  useEffect(() => {
-    if (props.child.VotesRemaining === 0) {
-      setCanVote(false);
-    }
-  }, [props.child]);
+  // useEffect(() => {
+  //   if (props.child.VotesRemaining === 0) {
+  //     setCanVote(false);
+  //   }
+  // }, [props.child]);
 
-  useEffect(() => {
-    getChildSquad(user, props.child.id).then(squad => {
-      getFaceoffsForMatchup(user, squad.ID, props.child.id).then(
-        allFaceoffs => {
-          props.setMemberId(squad);
-          props.setSquadFaceoffs(allFaceoffs);
-        }
-      );
-    });
+  // useEffect(() => {
+  //   getChildSquad(user, props.child.id).then(squad => {
+  //     getFaceoffsForMatchup(user, squad.ID, props.child.id).then(
+  //       allFaceoffs => {
+  //         props.setMemberId(squad);
+  //         props.setSquadFaceoffs(allFaceoffs);
+  //       }
+  //     );
+  //   });
 
-    // eslint-disable-next-line
-  }, [user]);
+  //   // eslint-disable-next-line
+  // }, [user]);
 
   return (
     <>
-      {isAuthenticated && !userInfo && (
+      <RenderMatchUp
+        {...props}
+        userInfo={userInfo}
+        canVote={canVote}
+        votesRemaining={props.child.VotesRemaining}
+      />
+      {/* {isAuthenticated && !userInfo && (
         <LoadingComponent message="Loading..." />
       )}
       {isAuthenticated && userInfo && props.faceoffs && (
@@ -71,7 +77,7 @@ function MatchUpContainer({ LoadingComponent, ...props }) {
           canVote={canVote}
           votesRemaining={props.child.VotesRemaining}
         />
-      )}
+      )} */}
     </>
   );
 }

--- a/src/components/pages/MatchUp/RenderMatchUp.js
+++ b/src/components/pages/MatchUp/RenderMatchUp.js
@@ -55,7 +55,7 @@ const RenderMatchUp = props => {
           instructions={modalInstructions.matchUp}
         />
       )}
-      <div className="matchup-container">
+      {/* <div className="matchup-container">
         <Row className="toprow">
           <Col className="green-box" xs={24} sm={13}>
             {faceoffs[0] && (
@@ -119,7 +119,7 @@ const RenderMatchUp = props => {
           <br />
           {props.VotesRemaining} votes left
         </Button>
-      </div>
+      </div> */}
     </>
   );
 };

--- a/src/components/pages/MatchUp/RenderMatchUp.js
+++ b/src/components/pages/MatchUp/RenderMatchUp.js
@@ -13,6 +13,10 @@ const RenderMatchUp = props => {
   const [faceoffs, setFaceoffs] = useState([]);
   const [modalVisible, setModalVisible] = useState(true);
 
+  const goToChildDashboard = () => {
+    push('/child/dashboard');
+  };
+
   useEffect(() => {
     if (props.child.VotesRemaining <= 9) {
       setModalVisible(false);
@@ -37,7 +41,25 @@ const RenderMatchUp = props => {
         pointsToWin={true}
         votesRemaining={true}
       />
-      <QuestionCircleOutlined
+      {/* REMOVE ONCE DESIGN WORK BEGINS - START */}
+      <div className={'under-construction'}>
+        <div className={'rectangle-126'} style={{ margin: '3rem' }}>
+          <h1>Coming Soon</h1>
+        </div>
+        <div className={'under-construction-content'}>
+          <h1>Under Construction!</h1>
+          <h1>Match Up UI Coming Soon!</h1>
+        </div>
+        <Button
+          style={{ margin: '1rem' }}
+          className="back-btn"
+          onClick={goToChildDashboard}
+        >
+          Back to Child Dashboard
+        </Button>
+      </div>
+      {/* REMOVE ONCE DESIGN WORK BEGINS - END */}
+      {/* <QuestionCircleOutlined
         className="question-icon"
         onClick={() => {
           setModalVisible(true);
@@ -54,7 +76,7 @@ const RenderMatchUp = props => {
           }}
           instructions={modalInstructions.matchUp}
         />
-      )}
+      )} */}
       {/* <div className="matchup-container">
         <Row className="toprow">
           <Col className="green-box" xs={24} sm={13}>

--- a/src/index.js
+++ b/src/index.js
@@ -252,7 +252,7 @@ function App() {
         {/* ROUTE EXISTS / NO PAGE EXISTS OK to DELETE / Will need to be replaced under /gameplay route */}
         <ProtectedRoute
           exact
-          path="/child/match-up"
+          path="/match-up"
           component={() => <MatchUp LoadingComponent={ChildLoadingComponent} />}
         />
         {/* ROUTE EXISTS OK to DELETE / returns user to /child/dashboard / Will need to be replaced under /gameplay route */}


### PR DESCRIPTION
This PR was to find and research the useablitiy of the existing Matchup page in the legacy code. there is clear logic making an api call to grab the children for the matchup and assuming that it is for future usage but needing to be updated in current styling requirements I commented out the api calls that were breaking it and then added the under construction template 

This completes the game play path for single player child. this and the other four pages need to be refactored to the  GamePlayMain.js switch statement to function on the /gameplay path after /gameplay has mounted. 


