### PR TITLE
Feature/route game play main with game mode

### DIFF
--- a/src/components/pages/ChildDashboard/RenderChildDashboard.js
+++ b/src/components/pages/ChildDashboard/RenderChildDashboard.js
@@ -15,7 +15,7 @@ const RenderChildDashboard = props => {
   const [modalVisible, setModalVisible] = useState(false);
 
   const handleAcceptMission = e => {
-    push('/gameplay/mission/read');
+    push('/gameplay/gamemode');
   };
 
   const handleJoinSquad = e => {

--- a/src/components/pages/GamePlay/GamePlayMain.js
+++ b/src/components/pages/GamePlay/GamePlayMain.js
@@ -12,6 +12,7 @@ import GamePlayMission from './GamePlayMission';
 import { TrophyRoom } from '../TrophyRoom/index';
 import GameModal from './GameModal';
 import Explosion from '../../../assets/images/gamemodeimg/explosion.png';
+import { Gamemode } from '../Gamemode';
 
 function GamePlayMain(props) {
   // Specify a base URL
@@ -44,6 +45,9 @@ function GamePlayMain(props) {
             baseURL={baseURL}
             enableModalWindow={enableModalWindow}
           />
+        </Route>
+        <Route path={`${baseURL}/gamemode`}>
+          <Gamemode baseURL={baseURL} />
         </Route>
 
         <Route path={`${baseURL}/mission`}>

--- a/src/components/pages/Gamemode/Gamemode.js
+++ b/src/components/pages/Gamemode/Gamemode.js
@@ -56,7 +56,6 @@ const Gamemode = ({ ...props }) => {
         : props.child.gamemode.mode === 'select' &&
           !props.child.gamemode.sp && (
             <div className="dash-container">
-              <Header />
               <div className="single-button-container">
                 <Button className="single-btn" onClick={startSinglePlayerMode}>
                   Single Player


### PR DESCRIPTION
In this PR, the route from child dashboard to gameplay, and then, to gamemode component has been created.

Motivation.
We wanted the child dashboard to automatically go to the gamemode component after the accept the mission button was pressed by the child.

Changes.
1.In Gamemode component on line 59, I deleted a Header component. There were two header components being rendered and I simply removed this one so only one header component is being rendered.

2.In RenderChildDashboard on line 18, I changed the redirect from gameplay/mission/read to gameplay/gamemode. That way you're redirected to the gamemode component.

3.In GamePlayMain on line 49, I created the route to gamemode component.

Trello Card: https://trello.com/c/DmFHv7Sv/685-game-play-logic-routing-path-cleanup

PR submission video(Has a demo towards the end): https://drive.google.com/file/d/17uNqm5Pmp85yqfO1yukqU20L991g8SrE/view?usp=sharing