### PR TITLE
Connecting /gamemode path into user flow

### DIFF
--- a/src/components/pages/ChildDashboard/RenderChildDashboard.js
+++ b/src/components/pages/ChildDashboard/RenderChildDashboard.js
@@ -15,7 +15,7 @@ const RenderChildDashboard = props => {
   const [modalVisible, setModalVisible] = useState(false);
 
   const handleAcceptMission = e => {
-    push('/gameplay/mission/read');
+    push('/gamemode');
   };
 
   const handleJoinSquad = e => {

--- a/src/components/pages/Gamemode/Gamemode.js
+++ b/src/components/pages/Gamemode/Gamemode.js
@@ -46,7 +46,7 @@ const Gamemode = ({ ...props }) => {
 
   const startSinglePlayerMode = e => {
     e.preventDefault();
-    push('/gameplay');
+    push('/gameplay/mission/read');
   };
 
   return (


### PR DESCRIPTION
This is a simple PR tying in the new /gamemode logic into user flow. 

The reason for this is to ensure smooth and accurate traversal through the child gameplay path from Parent Dashboard. 

Two locations were changed to accomplish this. Simply pointing the two nodes at each other by changing the path= logic. 

User now flows from Play Game button to Child Dashboard. From the dashboard it pushes to game mode where the user chooses single or multiplayer. 

From there the flow takes user to the reading stage of game play