### PR TITLE
Feature/routing child dashboard buttons to correct  paths

### DIFF
--- a/src/components/pages/ChildDashboard/RenderChildDashboard.js
+++ b/src/components/pages/ChildDashboard/RenderChildDashboard.js
@@ -27,7 +27,7 @@ const RenderChildDashboard = props => {
   };
 
   const handleLeaderboard = e => {
-    push('/gameplay/trophy-room');
+    push('/leaderboard');
   };
 
   return (

--- a/src/components/pages/ChildDashboard/RenderChildDashboard.js
+++ b/src/components/pages/ChildDashboard/RenderChildDashboard.js
@@ -19,11 +19,11 @@ const RenderChildDashboard = props => {
   };
 
   const handleJoinSquad = e => {
-    push('/child/join');
+    push('/join');
   };
 
   const handleChangeAvatar = event => {
-    push('/child/change-avatar');
+    push('/change-avatar');
   };
 
   const handleLeaderboard = e => {

--- a/src/components/pages/Leaderboard/RenderLeaderboard.js
+++ b/src/components/pages/Leaderboard/RenderLeaderboard.js
@@ -12,7 +12,7 @@ const RenderLeaderboard = props => {
   const { push } = useHistory();
 
   const dashboard = () => {
-    push('/child/dashboard');
+    push('/dashboard');
   };
 
   return (

--- a/src/index.js
+++ b/src/index.js
@@ -295,7 +295,7 @@ function App() {
         />
         {/* INCOMPLETE page exists. NEEDS DATA/ STYLE New path to point to /gameplay/dashboard/change-avatar NOT for DELETE */}
         <ProtectedRoute
-          path="/child/change-avatar"
+          path="/change-avatar"
           component={() => (
             <ChangeAvatar LoadingComponent={ChildLoadingComponent} />
           )}

--- a/src/index.js
+++ b/src/index.js
@@ -288,7 +288,7 @@ function App() {
         {/* FOUNDATION CODE exists. NEEDS DATA New path to point to /gameplay/dashboard/leaderboard NOT for DELETE */}
         <ProtectedRoute
           exact
-          path="/child/leaderboard"
+          path="/leaderboard"
           component={() => (
             <Leaderboard LoadingComponent={ChildLoadingComponent} />
           )}


### PR DESCRIPTION
This PR sets connects the Leaderboard component into the child dashboard and points buttons towards incoming user flow paths /join and /change-avatar. 

This ensures that the child dashboard is now pointing fully into current and intended user flow. 

/change-avatar page is rendering and awaiting an under construction template addition

/join is 404 needing a page created using under construction template