### PR TITLE
Fix less styling on child dashboard trophy room button to be consiste…

### DIFF
--- a/src/components/pages/ChildDashboard/RenderChildDashboard.js
+++ b/src/components/pages/ChildDashboard/RenderChildDashboard.js
@@ -85,7 +85,7 @@ const RenderChildDashboard = props => {
             />
           </Col>{' '}
           <Col
-            className="adventure-passport"
+            className="trophy-room-button"
             xs={24}
             sm={12}
             onClick={handleTrophyRoom}

--- a/src/styles/less/ChildDashboard.less
+++ b/src/styles/less/ChildDashboard.less
@@ -13,7 +13,7 @@
   }
   .ant-col.ant-col-13.accept-mission,
   .ant-col.ant-col-11.change-avatar,
-  .ant-col.ant-col-11.adventure-passport,
+  .ant-col.ant-col-11.trophy-room-button,
   .ant-col.ant-col-13.trophy-room {
     @media @mobile {
       max-width: 100%;
@@ -23,7 +23,7 @@
   .accept-mission,
   .accept-mission-ga1,
   .change-avatar,
-  .adventure-passport,
+  .trophy-room-button,
   .trophy-room,
   .leaderboard {
     border: 5px solid @header-nero;
@@ -64,22 +64,22 @@
       border-width: 0.25rem 0.5rem 0.5rem 0.5rem;
     }
   }
-  div.adventure-passport {
-    border-width: 0.75rem 0.375rem 0.75rem 0.75rem;
-    @media @tablet {
-      border-width: 0.5rem 0.25rem 0.5rem 0.5rem;
-    }
-    @media @mobile {
-      border-width: 0.5rem 0.5rem 0.25rem 0.5rem;
-    }
-  }
-  div.leaderboard {
+  div.trophy-room-button {
     border-width: 0.75rem 0.75rem 0.75rem 0.375rem;
     @media @tablet {
       border-width: 0.5rem 0.5rem 0.5rem 0.25rem;
     }
     @media @mobile {
       border-width: 0.25rem 0.5rem 0.5rem 0.5rem;
+    }
+  }
+  div.leaderboard {
+    border-width: 0.75rem 0.375rem 0.75rem 0.75rem;
+    @media @tablet {
+      border-width: 0.5rem 0.25rem 0.5rem 0.5rem;
+    }
+    @media @mobile {
+      border-width: 0.5rem 0.5rem 0.25rem 0.5rem;
     }
   }
 
@@ -141,7 +141,7 @@
       align-items: center;
     }
   }
-  .adventure-passport {
+  .trophy-room-button {
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -149,12 +149,12 @@
     background: @bright-sun;
   }
 
-  .adventure-passport img {
+  .trophy-room-button img {
     position: relative;
 
   }
 
-  .adventure-passport p {
+  .trophy-room-button p {
     position: absolute;
     z-index: 1;
 


### PR DESCRIPTION
This PR corrects the border on the child dashboard buttons so that they are even and consistent.  

We also clean up the classNames in the less file:

Changing deprecated className= adventure-passport to className=trophy-room-button.

This creates more consistent classNames in the component less file and is easier for future developers to understand.  
<img width="1170" alt="Screen Shot 2021-11-02 at 8 45 36 PM" src="https://user-images.githubusercontent.com/61174160/140007670-ee3e23e6-c66c-43a1-883d-b078e266a337.png">


