### PR TITLE
Bug/hamburger links corrected

### DIFF
--- a/src/components/common/Header.js
+++ b/src/components/common/Header.js
@@ -30,7 +30,7 @@ const ChildMenu = props => {
   };
 
   const leaderboardRedirect = () => {
-    push('/child/leaderboard');
+    push('/leaderboard');
   };
 
   return (

--- a/src/components/common/Header.js
+++ b/src/components/common/Header.js
@@ -22,7 +22,7 @@ const ChildMenu = props => {
   const { logout } = useAuth0();
 
   const childRedirect = () => {
-    push('/child/dashboard');
+    push('/dashboard');
   };
 
   const galleryRedirect = () => {


### PR DESCRIPTION
Changed the hamburger menu link to the correct leaderboard. Now properly redirects the user to '/leaderboard' instead of '/child/leaderboard'. Also changed the hamburger menu link for home. Was redirected to '/child/dashboard' corrected it to link to '/dashboard'. 

File changed: 
src/components/common/Header.js

Trello cards: https://trello.com/c/JsxTtgt9/703-child-dashboard-home-is-broken
https://trello.com/c/hboBbhtY/706-leaderboard-link-broken-in-hamburger-menu-needs-to-be-leaderboard