### PR TITLE
Feature/669 add choose user modal

### DIFF
--- a/src/components/common/ParentNavTopBar.js
+++ b/src/components/common/ParentNavTopBar.js
@@ -45,7 +45,14 @@ const ParentNavTopBar = props => {
       <div className="nav-right">
         <div className="link-container">
           <Link to="/dashboard">
-            <Button className="play-game-btn">PLAY GAME</Button>
+            <Button
+              onClick={evt => {
+                props.handlePlayGameButtonClick(evt);
+              }}
+              className="play-game-btn"
+            >
+              PLAY GAME
+            </Button>
           </Link>
           <Link to="/parent/faq">
             <span>FAQ</span>

--- a/src/components/pages/NewParentDashboard/ChooseChildModal.js
+++ b/src/components/pages/NewParentDashboard/ChooseChildModal.js
@@ -1,0 +1,51 @@
+//** Import Modules */
+import React, { useEffect } from 'react';
+import { gsap } from 'gsap';
+
+export default function ChooseChildModal(props) {
+  // Get the data to display
+  // const { title, description, buttonTxt } = props.modalData;
+
+  // Timeout timer before the modal is removed from the DOM(in ms)
+  const removeModalTimer = 1000;
+
+  // Functio to close the modal
+  const closeModal = () => {
+    gsap.to('.modal-container', { y: '100vh', duration: 0.5 });
+    gsap.to('#notification-modal', { opacity: 0, duration: 0.5, delay: 0.5 });
+    gsap.to('#notification-modal', {
+      display: 'none',
+      duration: 0.1,
+      delay: 1,
+    });
+
+    setTimeout(() => {
+      props.disableModalWindow();
+    }, removeModalTimer);
+  };
+
+  // Add some animation effects when component loads
+  useEffect(() => {
+    gsap.to('#notification-modal', {
+      display: 'flex',
+      duration: 0.1,
+    });
+    gsap.to('#notification-modal', { opacity: 1, duration: 0.5, delay: 0.5 });
+    gsap.to('.modal-container', { y: 0, duration: 0.5, delay: 1 });
+  });
+
+  return (
+    <div id="notification-modal">
+      <div className="modal-container">
+        <div className="modal-content">
+          <h1>I AM MOLLY</h1>
+          {/* <h3>{title}</h3>
+
+          <p>{description}</p>
+
+          <button onClick={closeModal}>{buttonTxt}</button> */}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/pages/NewParentDashboard/ChooseChildModal.js
+++ b/src/components/pages/NewParentDashboard/ChooseChildModal.js
@@ -38,7 +38,15 @@ export default function ChooseChildModal(props) {
     <div id="notification-modal">
       <div className="modal-container">
         <div className="modal-content" style={{ width: '70%' }}>
-          <h2 style={{ textAlign: 'center' }}>Choose Child</h2>
+          <h2
+            style={{
+              textAlign: 'center',
+              fontSize: '3rem',
+              fontStyle: 'italic',
+            }}
+          >
+            CHOOSE CHILD
+          </h2>
           <div
             style={{
               display: 'flex',
@@ -52,19 +60,22 @@ export default function ChooseChildModal(props) {
                 <div style={{ display: 'flexbox', flexDirection: 'column' }}>
                   <div
                     style={{
-                      backgroundColor: 'gray',
+                      backgroundColor: '#FFFFFF',
                       borderRadius: '100%',
-                      width: '125px',
-                      height: '125px',
+                      width: '111.54px',
+                      height: '111.54px',
                       display: 'flex',
                       overflow: 'hidden',
                       cursor: 'pointer',
+                      justifyContent: 'center',
                     }}
                     onClick={evt => handleCharacterClick(evt, ID)}
                   >
                     <img src={AvatarURL} />
                   </div>
-                  <span>{Name}</span>
+                  <span style={{ fontSize: '1.2rem' }}>
+                    {Name.toUpperCase()}
+                  </span>
                 </div>
               );
             })}

--- a/src/components/pages/NewParentDashboard/ChooseChildModal.js
+++ b/src/components/pages/NewParentDashboard/ChooseChildModal.js
@@ -4,7 +4,7 @@ import { gsap } from 'gsap';
 
 export default function ChooseChildModal(props) {
   // Get the data to display
-  // const { title, description, buttonTxt } = props.modalData;
+  const { childrenAccounts, handleCharacterClick } = props;
 
   // Timeout timer before the modal is removed from the DOM(in ms)
   const removeModalTimer = 1000;
@@ -37,13 +37,38 @@ export default function ChooseChildModal(props) {
   return (
     <div id="notification-modal">
       <div className="modal-container">
-        <div className="modal-content">
-          <h1>I AM MOLLY</h1>
-          {/* <h3>{title}</h3>
-
-          <p>{description}</p>
-
-          <button onClick={closeModal}>{buttonTxt}</button> */}
+        <div className="modal-content" style={{ width: '70%' }}>
+          <h2 style={{ textAlign: 'center' }}>Choose Child</h2>
+          <div
+            style={{
+              display: 'flex',
+              width: '100%',
+              justifyContent: 'space-between',
+            }}
+          >
+            {childrenAccounts.map(child => {
+              const { ID, Name, AvatarURL } = child;
+              return (
+                <div style={{ display: 'flexbox', flexDirection: 'column' }}>
+                  <div
+                    style={{
+                      backgroundColor: 'gray',
+                      borderRadius: '100%',
+                      width: '125px',
+                      height: '125px',
+                      display: 'flex',
+                      overflow: 'hidden',
+                      cursor: 'pointer',
+                    }}
+                    onClick={evt => handleCharacterClick(evt, ID)}
+                  >
+                    <img src={AvatarURL} />
+                  </div>
+                  <span>{Name}</span>
+                </div>
+              );
+            })}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/pages/NewParentDashboard/RenderNewParentDashboard.js
+++ b/src/components/pages/NewParentDashboard/RenderNewParentDashboard.js
@@ -46,8 +46,6 @@ const RenderNewParentDashboard = props => {
     console.warn('!!! GETTING PROFILE DATA');
     getProfileData()
       .then(res => {
-        console.log('~~ profile data');
-        console.log(res, res[0]);
         setParent({
           ...res[0],
           children: res.filter(user => user.type !== 'Parent'),

--- a/src/components/pages/NewParentDashboard/RenderNewParentDashboard.js
+++ b/src/components/pages/NewParentDashboard/RenderNewParentDashboard.js
@@ -12,23 +12,27 @@ import RenderWordCloud from '../WordCloud';
 import WordCountContainer from '../WordCountContainer/WordCountContainer';
 import ChooseChildModal from './ChooseChildModal';
 import { useHistory } from 'react-router-dom';
+// TEMPORARY HARD CODE - import of image assets - remove when pulling state from BE or globally
+import pinkyWinky from '../../../assets/images/hero_images/hero10.png';
+import submarineBoy from '../../../assets/images/hero_images/hero3.png';
+import dad from '../../../assets/images/hero_images/hero5.png';
 
 const RenderNewParentDashboard = props => {
   const FAKE_CHILDREN = [
     {
       ID: 0,
       Name: 'Pinky Winky',
-      AvatarURL: 'https://scribble-stadium.s3.amazonaws.com/avatars/01.svg',
+      AvatarURL: pinkyWinky,
     },
     {
       ID: 1,
       Name: 'Submarine Boy',
-      AvatarURL: 'https://scribble-stadium.s3.amazonaws.com/avatars/02.svg',
+      AvatarURL: submarineBoy,
     },
     {
       ID: 2,
       Name: 'Dad',
-      AvatarURL: 'https://scribble-stadium.s3.amazonaws.com/avatars/03.svg',
+      AvatarURL: dad,
     },
   ];
 

--- a/src/components/pages/NewParentDashboard/RenderNewParentDashboard.js
+++ b/src/components/pages/NewParentDashboard/RenderNewParentDashboard.js
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 import { setParent } from '../../../state/actions/parentActions';
 import RenderWordCloud from '../WordCloud';
 import WordCountContainer from '../WordCountContainer/WordCountContainer';
+import ChooseChildModal from './ChooseChildModal';
 
 const RenderNewParentDashboard = props => {
   const { user } = useAuth0();
@@ -28,7 +29,7 @@ const RenderNewParentDashboard = props => {
       });
   }, [setParent, user]);
   return (
-    <div>
+    <div id="parent-dashboard-page">
       <Layout className="newparent-dashboard">
         <ParentNavTopBar />
         <div className="renderWordCloud">
@@ -47,6 +48,8 @@ const RenderNewParentDashboard = props => {
           </div>
         </Layout>
       </Layout>
+
+      <ChooseChildModal />
     </div>
   );
 };

--- a/src/components/pages/NewParentDashboard/RenderNewParentDashboard.js
+++ b/src/components/pages/NewParentDashboard/RenderNewParentDashboard.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Layout } from 'antd';
 import { useAuth0 } from '@auth0/auth0-react';
 import { getProfileData } from '../../../api';
@@ -11,14 +11,39 @@ import { setParent } from '../../../state/actions/parentActions';
 import RenderWordCloud from '../WordCloud';
 import WordCountContainer from '../WordCountContainer/WordCountContainer';
 import ChooseChildModal from './ChooseChildModal';
+import { useHistory } from 'react-router-dom';
 
 const RenderNewParentDashboard = props => {
+  const FAKE_CHILDREN = [
+    {
+      ID: 0,
+      Name: 'Pinky Winky',
+      AvatarURL: 'https://scribble-stadium.s3.amazonaws.com/avatars/01.svg',
+    },
+    {
+      ID: 1,
+      Name: 'Submarine Boy',
+      AvatarURL: 'https://scribble-stadium.s3.amazonaws.com/avatars/02.svg',
+    },
+    {
+      ID: 2,
+      Name: 'Dad',
+      AvatarURL: 'https://scribble-stadium.s3.amazonaws.com/avatars/03.svg',
+    },
+  ];
+
+  const history = useHistory();
   const { user } = useAuth0();
   const { setParent } = props;
+  const [childrenAccounts, setChildrenAccounts] = useState(FAKE_CHILDREN);
+  const [modalVisible, setModalVisible] = useState(false);
 
   useEffect(() => {
+    console.warn('!!! GETTING PROFILE DATA');
     getProfileData()
       .then(res => {
+        console.log('~~ profile data');
+        console.log(res, res[0]);
         setParent({
           ...res[0],
           children: res.filter(user => user.type !== 'Parent'),
@@ -31,7 +56,12 @@ const RenderNewParentDashboard = props => {
   return (
     <div id="parent-dashboard-page">
       <Layout className="newparent-dashboard">
-        <ParentNavTopBar />
+        <ParentNavTopBar
+          handlePlayGameButtonClick={evt => {
+            evt.preventDefault();
+            setModalVisible(true);
+          }}
+        />
         <div className="renderWordCloud">
           <RenderWordCloud />
         </div>
@@ -49,7 +79,15 @@ const RenderNewParentDashboard = props => {
         </Layout>
       </Layout>
 
-      <ChooseChildModal />
+      {modalVisible && (
+        <ChooseChildModal
+          childrenAccounts={childrenAccounts}
+          handleCharacterClick={(evt, childId) => {
+            console.warn('We should set the selected child account here.');
+            history.push('/dashboard');
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/src/styles/less/ParentDashboard.less
+++ b/src/styles/less/ParentDashboard.less
@@ -71,6 +71,65 @@
   }
 }
 
+#parent-dashboard-page {
+
+
+  /* notification-modal */
+  #notification-modal {
+    position: fixed;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0, 0, 0, 0.5);
+    top: 0;
+    left: 0;
+    z-index: 999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    display: none;
+
+    .modal-container {
+      background: url(../../assets/images/gamemodeimg/modal.png);
+      background-size: cover;
+      width: 720px;
+      height: 520px;
+      transform: translateY(-100vh);
+
+      .modal-content {
+        padding: 20px 5%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        flex-direction: column;
+        font-family: 'atma';
+
+        h3 {
+          font-size: 3rem;
+          text-transform: uppercase;
+        }
+
+        p {
+          font-size: 1.5rem;
+          line-height: 1.5em;
+        }
+
+        button {
+          width: auto;
+          height: auto;
+          border-radius: 5px;
+          border: #333d3e 3px solid;
+          padding: 5px 15px;
+          font-family: 'atma';
+          font-size: 1.5rem;
+          cursor: pointer;
+          background: white;
+        }
+      }
+    }
+  }
+}
 @media @tablet {
   .parent-dashboard {
     .heading-section {


### PR DESCRIPTION
## Current Progress

Screen recording is a bit wonky w/ cursor position. Clicking a child's avatar redirects to the `/dashboard` route. There is a callback in the `renderNewParentDashboard.js` file where you can use the selected child's ID to set their profile when the backend is fixed.

![2pdyaz7SrP](https://user-images.githubusercontent.com/21160325/140450587-b5a2398b-d20e-41fb-b6d7-f74ffdebfc38.gif)

## Notes

- Modal background is an image, not just a hex color. Will likely need to modify in original figma file and export
- Other misc. color issues still need to be resolved
- Data is mocked because `/profiles` endpoint is broken

STYLE update MADE:
<img width="949" alt="Screen Shot 2021-11-08 at 1 31 07 PM" src="https://user-images.githubusercontent.com/61174160/140829090-fc158e8d-bba6-4844-9a5d-36bf7a3792bf.png">


