### PR TITLE
get hover effect to the trophy-room button

### DIFF
--- a/src/styles/less/ChildDashboard.less
+++ b/src/styles/less/ChildDashboard.less
@@ -289,3 +289,12 @@
     max-height: 100%;
   }
 }
+
+.trophy-room-button:hover {
+  opacity: 75%;
+
+  img {
+    max-width: 100%;
+    max-height: 100%;
+  }
+}


### PR DESCRIPTION
This PR gives Trophy-Room- button some hover effect to keep everything consistent on the child Dashboard:
only one file has been changed in this PR
./src/styles/less/childDashboard.less.
line 293-300 

styled it to match the other 3 buttons on childDashboard. originally the Trophy-Room- Button was missing hover effect.

This, 
Resolves Trello card: https://trello.com/c/YbU6pN8E/755-add-hover-to-trophy-room-card-on-child-dashboard

