### PR TITLE
Bug/Leaderboard backButton style issue-fix

### DIFF
--- a/src/components/pages/Leaderboard/RenderLeaderboard.js
+++ b/src/components/pages/Leaderboard/RenderLeaderboard.js
@@ -19,7 +19,11 @@ const RenderLeaderboard = props => {
   return (
     <>
       <Header displayMenu={true} title="Scribble Stadium" />
-      <Button style={{ margin: '1rem' }} onClick={dashboard}>
+      <Button
+        className="back-btn"
+        style={{ margin: '1rem' }}
+        onClick={dashboard}
+      >
         Back to Child Dashboard
       </Button>
       <div className="trophy-container">

--- a/src/styles/less/TrophyRoom.less
+++ b/src/styles/less/TrophyRoom.less
@@ -250,6 +250,11 @@
   color: #fff !important;
   font-family: 'atma';
   font-size: 2rem !important;
+  opacity: 85%;
+  &:hover {
+    opacity: 100%;
+    border-color: #ff9100 !important;
+  }
 }
 
 .under-construction-content {


### PR DESCRIPTION
• Added className='back-btn' to the Button in RenderLeaderboard.js for style issue fix.
• Small changes for 'back-btn' class in TrophyRoom.less hover effect changes opacity.
Before
![old_back-btn](https://user-images.githubusercontent.com/68477278/141032095-a01e7f46-ec5a-47e8-b978-53a228fd4945.jpg)
after
![new_back-btn](https://user-images.githubusercontent.com/68477278/141032126-f1370897-c48f-4052-946f-1994edf73031.jpg)
