### PR TITLE
removed the text main from the homepage

### DIFF
--- a/src/components/pages/WordCloud/CropCloud.js
+++ b/src/components/pages/WordCloud/CropCloud.js
@@ -37,7 +37,6 @@ export default function CropCloud() {
           src={`data:image/png;base64, ${placeholderCloud.data}`}
         />
       </div>
-      main
     </div>
   );
 }


### PR DESCRIPTION

Just removed the text "main" from cropCloud.js
