### PR TITLE
updates uniformity between writing submission page to match drawing sub and figma

### DIFF
--- a/src/components/pages/GamePlay/GameWriteStep.js
+++ b/src/components/pages/GamePlay/GameWriteStep.js
@@ -113,21 +113,13 @@ export default function GameWriteStep(props) {
           <img src={boyImg} alt="A boy" className="boy-img" />
 
           <div className="step-description">
-            <h3>Don’t forget!</h3>
-
-            {fileList.length === 0 ? (
-              <p>
-                When your story is complete, snap a photo of your pages and
-                upload them.
-              </p>
-            ) : (
-              <p>Double check that you’re uploading the right photo!</p>
-            )}
-
+            <p style={{ fontWeight: '100 !important', width: '350px' }}>
+              Make sure you're uploading the right photo.
+            </p>
             <UploadDocs
               listType="picture"
               uploadButtonClassname="upload-picture"
-              uploadButtonText="Upload Your Writing"
+              uploadButtonText="Upload your story"
               handleChangeExtra={handleChange}
               handleSubmit={handleSubmit}
               alternateHandleSubmission={true}

--- a/src/styles/less/GamemodeStyles.less
+++ b/src/styles/less/GamemodeStyles.less
@@ -1,6 +1,5 @@
 //** Gameplay Styles
 #gameplay {
-
   /* Header Styles */
   .hero {
     margin-bottom: 50px;
@@ -126,7 +125,7 @@
         }
       }
     }
-    @media(max-width: 800px) {
+    @media (max-width: 800px) {
       width: 87%;
       #step-1 {
         width: 40%;
@@ -136,7 +135,9 @@
       h3 {
         margin-top: 3rem;
       }
-      #step-1, #step-2, #step-3 {
+      #step-1,
+      #step-2,
+      #step-3 {
         width: 50%;
       }
     }
@@ -145,17 +146,20 @@
         transform: scale(75%);
         margin-bottom: 0;
       }
-      #step-1, #step-2, #step-3 {
+      #step-1,
+      #step-2,
+      #step-3 {
         transform: scale(75%);
       }
     }
     @media (max-width: 300px) {
       width: 90%;
-      #step-1, #step-2, #step-3 {
+      #step-1,
+      #step-2,
+      #step-3 {
         width: 15%;
       }
     }
-
   }
 
   /* Inside step content where the story, draw, or write content is */
@@ -255,13 +259,12 @@
           font-size: 2.5rem;
           text-transform: uppercase;
         }
-
-        p {
-          font-size: 1.5rem;
-          font-weight: 300;
-        }
       }
 
+      .step-description p {
+        font-size: 1.5rem;
+        font-weight: 100 !important;
+      }
       .ant-upload-list {
         margin-bottom: 25px;
       }


### PR DESCRIPTION
The purpose of this pr is to update the writing submission page to uniformity with it's sibling pages and more accurately align with the figma wireframe. 

Pages updated: 

GameWriteStep - verbiage adjusted to match the required verbiage in figma
GamemodesStyles.less - contained the width of the p element ised to render "Make sure you're uploading the right phote" to force a break between "the" and "right"


This PR solves the issue of incorrect styling and ensures that all submission sibling pages match stylistically
