### PR TITLE
Implement a warning system that does not allow the child to move on to battle until they have their drawing submitted

### DIFF
--- a/src/components/pages/GamePlay/GameWriteStep.js
+++ b/src/components/pages/GamePlay/GameWriteStep.js
@@ -20,6 +20,13 @@ export default function GameWriteStep(props) {
   // State to help when uploading
   const [isUploading, setIsUploading] = useState(false);
 
+  // Enable the modal window to warn about no draw submittion
+  const warnData = {
+    title: 'Hold up there parner!',
+    description: 'you must submit a drawing in order to battle.',
+    buttonTxt: 'back to drawing',
+  };
+
   // This handles what happens when a picture is added/removed
   const handleChange = data => {
     setFileList(data);
@@ -45,11 +52,15 @@ export default function GameWriteStep(props) {
         buttonTxt: "Let's Go!",
       };
 
-      props.enableModalWindow(modalData);
+      //props.enableModalWindow(modalData);
 
       setIsUploading(false);
     }, triggerSubmitTimer);
-    history.push('/child/next-steps');
+    if (props.submissionData.HasDrawn) {
+      history.push('/child/next-steps');
+    } else {
+      props.enableModalWindow(warnData);
+    }
   };
 
   // This function handles when we make a full submission of the entire mission(after reading, drawing, and writing)

--- a/src/components/pages/GamePlay/GameWriteStep.js
+++ b/src/components/pages/GamePlay/GameWriteStep.js
@@ -22,7 +22,7 @@ export default function GameWriteStep(props) {
 
   // Enable the modal window to warn about no draw submittion
   const warnData = {
-    title: 'Hold up there parner!',
+    title: 'Hold up there partner!',
     description: 'you must submit a drawing in order to battle.',
     buttonTxt: 'back to drawing',
   };


### PR DESCRIPTION
The problem with this bug is that in order for the user to properly compete in battle mode, they need to have submitted a drawing and a page of writing. Currently, if the user tries to submit and move on to battle with just writing, nothing pops up to warn or stop them from doing that. 

What I did was create a modal that activates if the user hasn't submitted a drawing. Upon saving their writing, the app usually routes them to the next step. I added in an if statement to check whether they have also submitted a drawing. If they haven't then the modal activates and if they have then they are routed forward like usual.

Loom video: https://www.loom.com/share/7683ae42a2fc44da9ce46c743501df02

Trello card: https://trello.com/c/99SzmWPt/742-gameplay-mission-draw-read-write-begin-battle-wont-begin-without-draw-no-warning-or-direction-to-complete-draw-step