### PR TITLE
fix footer className warning

### DIFF
--- a/src/components/common/ChildFooter.js
+++ b/src/components/common/ChildFooter.js
@@ -11,7 +11,7 @@ export default function ParentFooter(props) {
   return (
     <footer className={layoutContainerCheck}>
       <div className="inner-container">
-        <div class="copyright">©{curYear} Story Squad HQ</div>
+        <div className="copyright">©{curYear} Story Squad HQ</div>
       </div>
     </footer>
   );

--- a/src/components/common/ParentFooter.js
+++ b/src/components/common/ParentFooter.js
@@ -35,7 +35,7 @@ export default function ParentFooter(props) {
             </Link>
           </div>
         </nav>
-        <div class="copyright">©{curYear} Story Squad HQ</div>
+        <div className="copyright">©{curYear} Story Squad HQ</div>
       </div>
     </footer>
   );


### PR DESCRIPTION
# Pull Request Template

## Description
• Use className property to fix error in parent and child footer

Add a summary that address the following:

- motivation/purpose for the feature
clear the warning displayed in console and correct attribute for jsx

- What were those changes
fixing an attribute set for a div from class to className

- What issues were fixed
the attribute class for a html element needs to be in jsx convention to render correctly

- Provide the link to the user story it is referencing in Trello board or other supporting document


## Commits Checklist

- [x] commits have clear title names
- [x] commit has descriptive message of what has changed
- [x] more small commits than less big commits

## Code Checklist

- [x] code is formatted appropriately
- [x] code meets DRY standards
- [x] no dead code (check for logs and print statements)
- [x] no TODOS instead necessary comments
- [x] code follows Scribble Stadium standards for:
  - Language
  - Framework
  - Libraries

### PRs needs to be reviewed by at least 2 team members

- TPL is the 3rd reviewer
- Lots of comments and suggestions, please!

[Pull Request Rubric](https://www.notion.so/1fc04e4fedeb429ba873b7c68d281707?v=74054da7991341c0bf970f39410c43da)
