### PR TITLE
Fixed logic on Winner page play again button & style issues

### DIFF
--- a/src/components/pages/WinnerPage/PlayAgainButtonAnimation.js
+++ b/src/components/pages/WinnerPage/PlayAgainButtonAnimation.js
@@ -27,12 +27,9 @@ const PlayAgainButtonAnimation = () => {
 
   return (
     <div className={'playagainbtn'}>
-      <a href={goToChildDashboard}>
-        {' '}
-        <button onclick={playAgain} id="playbtn">
-          Play Again
-        </button>{' '}
-      </a>
+      <button onClick={playAgain} id="playbtn">
+        Play Again
+      </button>{' '}
       <ul id="output"></ul>
     </div>
   );

--- a/src/components/pages/WinnerPage/PlayAgainButtonAnimation.js
+++ b/src/components/pages/WinnerPage/PlayAgainButtonAnimation.js
@@ -27,7 +27,7 @@ const PlayAgainButtonAnimation = () => {
 
   return (
     <div className={'playagainbtn'}>
-      <button onClick={playAgain} id="playbtn">
+      <button onClick={playAgain} id="playbtn" className={'play-again-btn'}>
         Play Again
       </button>{' '}
       <ul id="output"></ul>

--- a/src/styles/less/WinnerPage.less
+++ b/src/styles/less/WinnerPage.less
@@ -35,17 +35,17 @@
   position: relative;
   right: 35%;
   top: 7.5%;
-  margin-bottom: 0;
+  margin-bottom: 1rem;
 }
 
 .winner-box {
   width: 35rem;
-  height: 40rem;
+  height: 35rem;
   left: 0px;
   top: 0px;
   border: 7px solid #e5e5e5;
   box-sizing: border-box;
-  padding: 2%;
+  padding: 1rem;
   align-self: center;
   display: flex;
   justify-content: center;
@@ -74,7 +74,7 @@
     font-style: normal;
     font-weight: normal;
     font-size: 40px;
-    line-height: 64px;
+    line-height: 100px;
     letter-spacing: 0.05em;
     color: #fbfbfb;
     position: absolute;
@@ -94,6 +94,19 @@
     animation: pulse 1s infinite;
     animation-timing-function: linear;
   }
+}
+
+.play-again-btn {
+  width: auto;
+  height: auto;
+  border-radius: 5px;
+  border: white 3px solid;
+  padding: 5px 15px;
+  font-family: 'atma';
+  font-size: 1.5rem;
+  cursor: pointer;
+  background: #6CEAE6;
+  margin-bottom: .1rem;
 }
 
 @keyframes slidein {

--- a/src/styles/less/WinnerPage.less
+++ b/src/styles/less/WinnerPage.less
@@ -39,8 +39,8 @@
 }
 
 .winner-box {
-  width: 550px;
-  height: 550px;
+  width: 35rem;
+  height: 40rem;
   left: 0px;
   top: 0px;
   border: 7px solid #e5e5e5;


### PR DESCRIPTION
This PR fixes the broken play again button on winner page, brings in the uniform button styling from the sibling pages so that all buttons match and addresses issues of responsiveness and element bunching within winner-container. 

This pull request is atomic in addressing only the issues of the winner page. Only two pages were adjusted. 

PlayAgainButtonAnimation.js
REMOVED  <a> element as wrapper to button fixing the warning message 
ADDED className to button element and changed onclick to onClick fixing the navigation logic

WinnerPage.less
Multiple styling fixes to fix container size, padding, and Y axis adjustments on text and button

Play Again button now works sending user to /child/play-again
