### PR TITLE
Made "currentDay" glow based on which bar is lit

### DIFF
--- a/src/components/pages/HeadsUpDisplay/Hud.js
+++ b/src/components/pages/HeadsUpDisplay/Hud.js
@@ -79,10 +79,18 @@ function Hud(props) {
           </div>
 
           <div className="days">
-            <div className="day1-3">Day 1 - 3</div>
-            <div className="day4">Day 4</div>
-            <div className="day5">Day 5</div>
-            <div className="day6-7">Day 6 - 7</div>
+            <div className={`day1-3 ${currentBar === 'bar1' && 'currentDay'}`}>
+              Day 1 - 3
+            </div>
+            <div className={`day4 ${currentBar === 'bar2' && 'currentDay'}`}>
+              Day 4
+            </div>
+            <div className={`day5 ${currentBar === 'bar3' && 'currentDay'}`}>
+              Day 5
+            </div>
+            <div className={`day6-7 ${currentBar === 'bar4' && 'currentDay'}`}>
+              Day 6 - 7
+            </div>
           </div>
         </Panel>
       </Collapse>

--- a/src/styles/less/Hud.less
+++ b/src/styles/less/Hud.less
@@ -277,10 +277,12 @@
 
 //State not done for this PT21
 .currentDay {
-  display: flex;
-  flex-flow: row wrap;
-  background-color: var(--green);
-  animation: pulse-animation 2s infinite;
+  color: var(--green);
+  text-shadow: -1px -1px 0 rgb(117, 117, 117), 1px -1px 0 rgb(117, 117, 117),
+    -1px 1px 0 rgb(117, 117, 117), 1px 1px 0 rgb(117, 117, 117),
+    0px 0px 20px rgba(198, 253, 126, 0.45);
+  @media @mobileLarge {
+  }
 }
 // State not done for this PT21
 .completedDay {

--- a/src/styles/less/Hud.less
+++ b/src/styles/less/Hud.less
@@ -178,7 +178,7 @@
   display: flex;
   margin-top: 1%;
 
-  @media @mobileLarge {
+  @media screen and (max-width: 500px) {
     display: none;
   }
 }

--- a/src/styles/less/Hud.less
+++ b/src/styles/less/Hud.less
@@ -1,272 +1,273 @@
 @import '~antd/dist/antd.less';
 @import '~antd/lib/style/themes/default.less';
+@import 'variables.less';
 
-:root{
-	--green: #c6fd7e;
-	--grey: #c7c7c7;
-	--white: white;
-	--bar-border-radius: 200px;
-	--font-size: 1.5rem;
+:root {
+  --green: #c6fd7e;
+  --grey: #c7c7c7;
+  --white: white;
+  --bar-border-radius: 200px;
+  --font-size: 1.5rem;
 }
 
 .HudContainer {
-    width: 100%;
-    background-color: #757575;
-    display: flex;
-    flex-direction: column;
-    letter-spacing: .2rem;
-    --min-height: 0.75rem;
-	--font-size: 1.5rem;
-	letter-spacing: 0.2rem;
+  width: 100%;
+  background-color: #757575;
+  display: flex;
+  flex-direction: column;
+  letter-spacing: 0.2rem;
+  --min-height: 0.75rem;
+  --font-size: 1.5rem;
+  letter-spacing: 0.2rem;
 }
 
 .countdown-timer-container {
-    width: 85%;
-    margin: 0 auto;
-    letter-spacing: .25rem;
+  width: 85%;
+  margin: 0 auto;
+  letter-spacing: 0.25rem;
 }
 
 .ctimer.pos-1 {
-    width: 50%;
-    text-align: center;
+  width: 50%;
+  text-align: center;
 }
 
 .ctimer.pos-2 {
-    margin-left: 33.33%;
-    width: 50%;
-    text-align: center;    
+  margin-left: 33.33%;
+  width: 50%;
+  text-align: center;
 }
 
 .ctimer.pos-3 {
-    margin-left: 63%;
-    width: 37%;
-    text-align: center;
+  margin-left: 63%;
+  width: 37%;
+  text-align: center;
 }
 
-
 .countdown-timer {
-    font-size: var(--font-size);
-	font-family: 'Bangers', cursive;
-	color: white;
+  font-size: var(--font-size);
+  font-family: 'Bangers', cursive;
+  color: white;
 }
 
 .progressionBar {
-    width: 85%;
-    border-radius: 15px;
-    border: 3px solid black;
-    display: flex;
-    flex-flow: row, wrap;
-    color: black;
-    background-color: var(--green);
-    font-size: var(--font-size);
-	font-weight: 500;
-	font-family: 'Bangers', cursive;
-    margin: 0 auto;
-
+  width: 85%;
+  border-radius: 15px;
+  border: 3px solid black;
+  display: flex;
+  flex-flow: row, wrap;
+  color: black;
+  background-color: var(--green);
+  font-size: var(--font-size);
+  font-weight: 500;
+  font-family: 'Bangers', cursive;
+  margin: 0 auto;
 }
 
 .progressionBarLoaded {
-    width: 85%;
-    border-radius: 15px;
-    border: 3px solid black;
-    display: flex;
-    flex-flow: row, wrap;
-    color: black;
-    background-image: var(--green);
-    font-size: var(--font-size);
-    font-weight: 500;
-    font-family: 'Bangers', cursive;
-    margin: 0 auto;
-
+  width: 85%;
+  border-radius: 15px;
+  border: 3px solid black;
+  display: flex;
+  flex-flow: row, wrap;
+  color: black;
+  background-image: var(--green);
+  font-size: var(--font-size);
+  font-weight: 500;
+  font-family: 'Bangers', cursive;
+  margin: 0 auto;
 }
 
-.progbtn{
-    display: flex;
-    flex-direction: column;
-    font-size: var(--font-size);
+.progbtn {
+  display: flex;
+  flex-direction: column;
+  font-size: var(--font-size);
 }
 
 .activity {
-    width: 16.666%;
-    text-align: center;
-    // This is how the I made the border angled on one side
-    transform: skewX(-15deg);
-    border-right: 3px solid black;
-    // This is to make the element seem less italicized
-    span {
-        transform: skewX(15deg);
-    }
-    &:nth-last-of-type(1) {
-        border-right: none;
-    }
+  width: 16.666%;
+  text-align: center;
+  // This is how the I made the border angled on one side
+  transform: skewX(-15deg);
+  border-right: 3px solid black;
+  // This is to make the element seem less italicized
+  span {
+    transform: skewX(15deg);
+  }
+  &:nth-last-of-type(1) {
+    border-right: none;
+  }
 }
 
-.activity .checkImg{
-   display: none;
+.activity .checkImg {
+  display: none;
 }
 
 // Checkmark img for completed activity to be added after made in house
 .completedActivity {
-    // background-color: var(--green);
-    //border-radius: 1px 0px 0px 0px;
-    width: 16.666%;
-    text-align: center;
-    // This is how the I made the border angled on one side
-    transform: skewX(-15deg);
-		padding: 8px;
-   // border-right: 3px solid black;
-    // This is to make the element seem less italicized
-    span {
-        transform: skewX(15deg);
-    }
-    &:nth-last-of-type(1) {
-        border-right: none;
-    }
+  // background-color: var(--green);
+  //border-radius: 1px 0px 0px 0px;
+  width: 16.666%;
+  text-align: center;
+  // This is how the I made the border angled on one side
+  transform: skewX(-15deg);
+  padding: 8px;
+  // border-right: 3px solid black;
+  // This is to make the element seem less italicized
+  span {
+    transform: skewX(15deg);
+  }
+  &:nth-last-of-type(1) {
+    border-right: none;
+  }
 }
 
-.completedActivity .checkImg{
-    display: inline;
+.completedActivity .checkImg {
+  display: inline;
 }
-
-
 
 .currentActivity {
-    background-color:  var(--white);
-    width: 16.666%;
-    text-align: center;
-    // This is how the I made the border angled on one side
-    transform: skewX(-15deg);
-    border: 8px solid #C6FD7E;;
-    //border-right: 3px solid black;
-    // This is to make the element seem less italicized
-    span {
-        transform: skewX(15deg);
-    }
-    &:nth-last-of-type(1) {
-        border-right: none;
-    }
-    animation: pulse-animation 2s infinite;
+  background-color: var(--white);
+  width: 16.666%;
+  text-align: center;
+  // This is how the I made the border angled on one side
+  transform: skewX(-15deg);
+  border: 8px solid #c6fd7e;
+  //border-right: 3px solid black;
+  // This is to make the element seem less italicized
+  span {
+    transform: skewX(15deg);
+  }
+  &:nth-last-of-type(1) {
+    border-right: none;
+  }
+  animation: pulse-animation 2s infinite;
 }
 
-.currentActivity .checkImg{
-    display: none;
-}
-
-.restActive {
-	padding: 8px;
+.currentActivity .checkImg {
+  display: none;
 }
 
 .restActive {
-	padding: 8px;
+  padding: 8px;
 }
 
 .restActive {
-	padding: 8px;
+  padding: 8px;
+}
+
+.restActive {
+  padding: 8px;
 }
 
 // This is the animation for current activity
 .pulse {
-    animation: pulse-animation 2s infinite;
+  animation: pulse-animation 2s infinite;
 }
 
 @keyframes pulse-animation {
-    0% {
-        box-shadow: 0 0 0 0px rgba(255, 255, 255, 0.4);
-    }
-    100% {
-        box-shadow: 0 0 0 20px rgba(255, 255, 255, 0);
-    }
+  0% {
+    box-shadow: 0 0 0 0px rgba(255, 255, 255, 0.4);
+  }
+  100% {
+    box-shadow: 0 0 0 20px rgba(255, 255, 255, 0);
+  }
 }
 
 .dayBars {
-	display: flex;
-	margin-top: 1%;
+  display: flex;
+  margin-top: 1%;
+
+  @media @mobileLarge {
+    display: none;
+  }
 }
 
 .bar1 {
-    width: 39%;
-	margin-left: 9%;
-    background-color: var(--grey);
-    min-height: var(--min-height);
-	border-radius: var(--bar-border-radius);
+  width: 39%;
+  margin-left: 9%;
+  background-color: var(--grey);
+  min-height: var(--min-height);
+  border-radius: var(--bar-border-radius);
 }
 
 .bar2 {
-    width: 11%;
-	margin-left: 3%;
-    background-color: var(--grey);
-    min-height: var(--min-height);
-	border-radius: var(--bar-border-radius);
+  width: 11%;
+  margin-left: 3%;
+  background-color: var(--grey);
+  min-height: var(--min-height);
+  border-radius: var(--bar-border-radius);
 }
 
 .bar3 {
-    width: 11%;
-	margin-left: 3%;
-    background-color: var(--grey);
-    min-height: var(--min-height);
-	border-radius: var(--bar-border-radius);
+  width: 11%;
+  margin-left: 3%;
+  background-color: var(--grey);
+  min-height: var(--min-height);
+  border-radius: var(--bar-border-radius);
 }
 
 .bar4 {
-    width: 11%;
-	margin-left: 3%;
-    background-color: var(--grey);
-    min-height: var(--min-height);
-	border-radius: var(--bar-border-radius);
+  width: 11%;
+  margin-left: 3%;
+  background-color: var(--grey);
+  min-height: var(--min-height);
+  border-radius: var(--bar-border-radius);
 }
 
 .currentBar {
-    background-color: var(--green);
+  background-color: var(--green);
 }
 
 .days {
-    display: flex;
-	margin-top: .5%;
+  display: flex;
+  margin-top: 0.5%;
 }
 
 .day1-3 {
-	display: flex;
-	margin-left: 9%;
-    width: 39%;
-	justify-content: center;
-	font-size: var(--font-size);
-	color: var(--white);
-	font-family: 'Bangers', cursive;
+  display: flex;
+  margin-left: 9%;
+  width: 39%;
+  justify-content: center;
+  font-size: var(--font-size);
+  color: var(--white);
+  font-family: 'Bangers', cursive;
 }
 
 .day4 {
-	display: flex;
-	width: 11%;
-	margin-left: 3%;
-	justify-content: center;
-	font-size: var(--font-size);
-	color: var(--white);
-	font-family: 'Bangers', cursive;
+  display: flex;
+  width: 11%;
+  margin-left: 3%;
+  justify-content: center;
+  font-size: var(--font-size);
+  color: var(--white);
+  font-family: 'Bangers', cursive;
 }
 
 .day5 {
-	display: flex;
-	width: 11%;
-	margin-left: 3%;
-	justify-content: center;
-	font-size: var(--font-size);
-	color: var(--white);
-	font-family: 'Bangers', cursive;
+  display: flex;
+  width: 11%;
+  margin-left: 3%;
+  justify-content: center;
+  font-size: var(--font-size);
+  color: var(--white);
+  font-family: 'Bangers', cursive;
 }
 
 .day6-7 {
-	display: flex;
-	width: 11%;
-	margin-left: 3%;
-	justify-content: center;
-	font-size: var(--font-size);
-	color:var(--white);
-	font-family: 'Bangers', cursive;
+  display: flex;
+  width: 11%;
+  margin-left: 3%;
+  justify-content: center;
+  font-size: var(--font-size);
+  color: var(--white);
+  font-family: 'Bangers', cursive;
 }
 
-[data-theme='compact'] .site-collapse-custom-collapse .site-collapse-custom-panel,
+[data-theme='compact']
+  .site-collapse-custom-collapse
+  .site-collapse-custom-panel,
 .site-collapse-custom-collapse .site-collapse-custom-panel {
-
   overflow: hidden;
   background: #757575;
   border: 0px;
@@ -276,38 +277,43 @@
 
 //State not done for this PT21
 .currentDay {
-    display: flex;
-    flex-flow: row wrap;
-    background-color: var(--green);
-    animation: pulse-animation 2s infinite;
+  display: flex;
+  flex-flow: row wrap;
+  background-color: var(--green);
+  animation: pulse-animation 2s infinite;
 }
 // State not done for this PT21
 .completedDay {
-    background-color: var(--green);
+  background-color: var(--green);
 }
-
 
 @media screen and (max-width: 500px) {
   .HudContainer .countdown-timer .progressionBar.progressBarLoaded {
     display: flex;
     flex-wrap: wrap;
     flex-direction: column;
-    height: 100px
+    height: 100px;
   }
 
- .progressionBarLoaded, .days {
-   display: block;
-   width: 100%;
- }
+  .progressionBarLoaded,
+  .days {
+    display: block;
+    width: 100%;
+  }
 
- .completedActivity, .activity, .currentActivity {
-   width: inherit;
-   transform: inherit;
-   border-bottom: 2px solid black;
-   border-right: none;
- }
- .day1-3, .day4, .day5, .day6-7 {
+  .completedActivity,
+  .activity,
+  .currentActivity {
+    width: inherit;
+    transform: inherit;
+    border-bottom: 2px solid black;
+    border-right: none;
+  }
+  .day1-3,
+  .day4,
+  .day5,
+  .day6-7 {
     margin-left: inherit;
-    width: 100%
- }
+    width: 100%;
+  }
 }


### PR DESCRIPTION
# Description

This is a continuation of PR #337 where I added in a slight glow to the "currentDay" as suggested by @bporch84 by added some styles to the `.currentDay` class as listed on [this Trello card](https://trello.com/c/l2epyhya/770-add-currentday-glow) to emphasize where the child user is along their mission/journey.

![addGlow to currentDay](https://user-images.githubusercontent.com/28786654/142138703-1e640f4e-3451-4f5e-92c3-7ef0edfa3e39.jpg)