### PR TITLE
Single player footer fix

### DIFF
--- a/src/components/pages/GamePlay/GameDrawStep.js
+++ b/src/components/pages/GamePlay/GameDrawStep.js
@@ -50,6 +50,7 @@ export default function GameDrawStep(props) {
         props.updateModalStatus('draw', true);
       }
 
+      props.updateFileSubmissionData('drawings', []);
       history.push(`${props.baseURL}/write`);
     }, triggerSubmitTimer);
   };

--- a/src/components/pages/GamePlay/GameDrawStep.js
+++ b/src/components/pages/GamePlay/GameDrawStep.js
@@ -135,7 +135,7 @@ export default function GameDrawStep(props) {
                 onClick={handleSubmit}
                 loading={isUploading}
               >
-                {isUploading ? 'Uploading...' : 'Save'}
+                {isUploading ? 'Uploading...' : 'Submit'}
               </Button>
             )}
 

--- a/src/components/pages/GamePlay/GameDrawStep.js
+++ b/src/components/pages/GamePlay/GameDrawStep.js
@@ -139,9 +139,9 @@ export default function GameDrawStep(props) {
               </Button>
             )}
 
-            <button className="skip-btn" onClick={handleSkip}>
+            <Button className="skip-btn" onClick={handleSkip}>
               I’d rather write
-            </button>
+            </Button>
           </div>
         </div>
       </div>

--- a/src/components/pages/GamePlay/GamePlayMain.js
+++ b/src/components/pages/GamePlay/GamePlayMain.js
@@ -68,7 +68,7 @@ function GamePlayMain(props) {
         <Route component={NotFoundPage} />
       </Switch>
 
-      <ChildFooter />
+      {/* <ChildFooter /> */}
 
       {enableModal && (
         <GameModal

--- a/src/components/pages/GamePlay/GamePlayMain.js
+++ b/src/components/pages/GamePlay/GamePlayMain.js
@@ -68,8 +68,6 @@ function GamePlayMain(props) {
         <Route component={NotFoundPage} />
       </Switch>
 
-      {/* <ChildFooter /> */}
-
       {enableModal && (
         <GameModal
           modalData={modalData}

--- a/src/components/pages/GamePlay/GameWriteStep.js
+++ b/src/components/pages/GamePlay/GameWriteStep.js
@@ -138,11 +138,11 @@ export default function GameWriteStep(props) {
               </Button>
             )}
 
-            <button className="skip-btn" onClick={handleSkip}>
+            <Button className="skip-btn" onClick={handleSkip}>
               {props.submissionData.HasDrawn
                 ? 'Just drawing, no story'
                 : "I'd rather draw"}
-            </button>
+            </Button>
 
             {/* This button is no longer needed as the page routes to next steps. If in the future a battle mode is implemented, this button will be used. */}
             {/* {props.battleReady && (

--- a/src/components/pages/GamePlay/GameWriteStep.js
+++ b/src/components/pages/GamePlay/GameWriteStep.js
@@ -47,6 +47,7 @@ export default function GameWriteStep(props) {
 
       props.enableModalWindow(modalData);
 
+      props.updateFileSubmissionData('writings', []);
       setIsUploading(false);
     }, triggerSubmitTimer);
     history.push('/child/next-steps');

--- a/src/components/pages/GamePlay/GameWriteStep.js
+++ b/src/components/pages/GamePlay/GameWriteStep.js
@@ -134,7 +134,7 @@ export default function GameWriteStep(props) {
                 onClick={handleSubmit}
                 loading={isUploading}
               >
-                {isUploading ? 'Uploading...' : 'Save'}
+                {isUploading ? 'Uploading...' : 'Submit'}
               </Button>
             )}
 

--- a/src/styles/less/GamemodeStyles.less
+++ b/src/styles/less/GamemodeStyles.less
@@ -320,12 +320,6 @@
 
       .skip-btn {
         background: none;
-        // cursor: pointer;
-        // padding: 0;
-        // font-size: 1.3rem;
-        // text-decoration: underline;
-        // height: auto;
-        // width: auto;
       }
 
       .battle-btn {

--- a/src/styles/less/GamemodeStyles.less
+++ b/src/styles/less/GamemodeStyles.less
@@ -320,12 +320,12 @@
 
       .skip-btn {
         background: none;
-        cursor: pointer;
-        padding: 0;
-        font-size: 1.3rem;
-        text-decoration: underline;
-        height: auto;
-        width: auto;
+        // cursor: pointer;
+        // padding: 0;
+        // font-size: 1.3rem;
+        // text-decoration: underline;
+        // height: auto;
+        // width: auto;
       }
 
       .battle-btn {


### PR DESCRIPTION
**Part of my ticket was to remove the footer in the single player cards. A different group has since updated the footer and made the footer more in line with the Figma. I don't think that removing the footer is going to be the direction that we are wanting to go. But it was in there, so it is completed.**

@derekjpeters What direction do we want for the footer ☝🏻

Changed the text when submitting a file from "Save" to "Submit"

Changed the "I'd rather draw" and "I'd rather write" buttons to be antd button components. They now stand out a lot more and are very obviously buttons.

After submitting a file, the submission field was not clearing. Added some logic that clears that now.


https://www.loom.com/share/5ad17e2913414bed936361c60434dfe3

https://trello.com/c/KVwUj2dd/714-single-player-gameplay-mission-write-see-checklist
https://trello.com/c/GF8uxVBQ/712-single-player-gameplay-mission-read-see-checklist
https://trello.com/c/YegIug3J/713-single-player-gameplay-mission-draw-see-checklist