### PR TITLE
fix 1st child currentActivity overflow for progress bar

### DIFF
--- a/src/styles/less/Hud.less
+++ b/src/styles/less/Hud.less
@@ -147,6 +147,14 @@
   &:nth-last-of-type(1) {
     border-right: none;
   }
+  &:nth-child(1) {
+    transform: translateX(1rem) skew(-20deg);
+    margin-bottom: .1rem;
+    margin-left: .1rem;
+    @media (max-width: 1100px) {
+      transform: translateX(1.2rem) skew(-20deg);
+    }
+  }
   animation: pulse-animation 2s infinite;
 }
 


### PR DESCRIPTION
# Pull Request Template

## Description

Add a summary that address the following:

- motivation/purpose for the feature
  fix the style issue with the overflow of the READ element when currentActivity is active.

- What were those changes
  uses a pseudo class for the 1st child element with a class of currentActivity and repositions this element to fit inside the progress bar.

- What issues were fixed
  READ element on the progress bar fits nicely inside, without clipping or hiding the nice pulse animation.

- Provide the link to the user story it is referencing in Trello board or other supporting document
  https://trello.com/c/sDa4n7ub


### PRs needs to be reviewed by at least 2 team members

- TPL is the 3rd reviewer
- Lots of comments and suggestions, please!

[Pull Request Rubric](https://www.notion.so/1fc04e4fedeb429ba873b7c68d281707?v=74054da7991341c0bf970f39410c43da)
