### PR TITLE
fixed bug where values can be set to negative numbers on the point share page

### DIFF
--- a/src/components/pages/PointShare/RenderPointShare.js
+++ b/src/components/pages/PointShare/RenderPointShare.js
@@ -264,7 +264,10 @@ const PointShare = props => {
                   style={{ color: '#6CEAE6', fontSize: '30px' }}
                   onClick={() => {
                     handlePointShare({
-                      value: storyOnePoints - 5,
+                      value:
+                        storyOnePoints >= 5
+                          ? storyOnePoints - 5
+                          : storyOnePoints,
                       pointSetter: setStoryOnePoints,
                       a: storyTwoPoints,
                       b: illustrationOnePoints,
@@ -308,7 +311,10 @@ const PointShare = props => {
                   style={{ color: '#6CEAE6', fontSize: '30px' }}
                   onClick={() => {
                     handlePointShare({
-                      value: illustrationOnePoints - 5,
+                      value:
+                        illustrationOnePoints >= 5
+                          ? illustrationOnePoints - 5
+                          : illustrationOnePoints,
                       pointSetter: setIllustrationOnePoints,
                       a: storyTwoPoints,
                       b: storyOnePoints,
@@ -364,7 +370,10 @@ const PointShare = props => {
                   style={{ color: '#6CEAE6', fontSize: '30px' }}
                   onClick={() => {
                     handlePointShare({
-                      value: storyTwoPoints - 5,
+                      value:
+                        storyTwoPoints >= 5
+                          ? storyTwoPoints - 5
+                          : storyTwoPoints,
                       pointSetter: setStoryTwoPoints,
                       a: storyOnePoints,
                       b: illustrationOnePoints,
@@ -414,7 +423,10 @@ const PointShare = props => {
                     style={{ color: '#6CEAE6', fontSize: '30px' }}
                     onClick={() => {
                       handlePointShare({
-                        value: illustrationTwoPoints - 5,
+                        value:
+                          illustrationTwoPoints >= 5
+                            ? illustrationTwoPoints - 5
+                            : illustrationTwoPoints,
                         pointSetter: setIllustrationTwoPoints,
                         a: storyTwoPoints,
                         b: illustrationOnePoints,


### PR DESCRIPTION
Why this was done: On the point share page there was a bug where the user was not prevented from decreasing the value past zero. Since negative numbers are not supposed to be used in the point share, it was necessary to prevent this from happening.

What was done: On each of the "CaretUpOutlined" buttons a ternary operator was added to make sure that when the user clicks it checks to see whether the current value is greater than or equal to five. If so, then we can decrease by five but if not then it returns the same value since that would go into the negatives.

Trello Card: https://trello.com/c/tRADzSOZ

Loom video: https://www.loom.com/share/232bb5bcbfde4807abe92458a0f66640
