### PR TITLE
fixed styling issue on "back to child dashboard" button on the leaderboard page

### DIFF
--- a/src/components/pages/Leaderboard/RenderLeaderboard.js
+++ b/src/components/pages/Leaderboard/RenderLeaderboard.js
@@ -19,7 +19,7 @@ const RenderLeaderboard = props => {
   return (
     <>
       <Header displayMenu={true} title="Scribble Stadium" />
-      <Button style={{ margin: '1rem' }} onClick={dashboard}>
+      <Button style={{ margin: '1rem', width: '15vw' }} onClick={dashboard}>
         Back to Child Dashboard
       </Button>
       <div className="trophy-container">

--- a/src/components/pages/Leaderboard/RenderLeaderboard.js
+++ b/src/components/pages/Leaderboard/RenderLeaderboard.js
@@ -19,7 +19,7 @@ const RenderLeaderboard = props => {
   return (
     <>
       <Header displayMenu={true} title="Scribble Stadium" />
-      <Button style={{ margin: '1rem', width: '15vw' }} onClick={dashboard}>
+      <Button style={{ margin: '1rem', width: 'auto' }} onClick={dashboard}>
         Back to Child Dashboard
       </Button>
       <div className="trophy-container">


### PR DESCRIPTION
Why this was done: On the "back to child dashboard" button of the leaderboard page, the text is too long for it so it extends beyond the button.

What was done: I added inline width styling of 15 view width to the button so it is just wide enough to include all the text and appear how it should.

Trello card: https://trello.com/c/ZL5AZXdE/707-leaderboard-back-to-child-dashboard-styling-issue
