### PR TITLE
Changed the onClick event  in the “Home” item under the header’s dropdown menu to route back to the Child’s Dashboard instead of going to the Parent’s Dashboard.

### DIFF
--- a/src/components/common/Header.js
+++ b/src/components/common/Header.js
@@ -21,7 +21,7 @@ const ChildMenu = props => {
   const { push } = useHistory();
   const { logout } = useAuth0();
 
-  const childRedirect = () => {
+  const dashboard = () => {
     push('/dashboard');
   };
 
@@ -38,7 +38,7 @@ const ChildMenu = props => {
       <Menu.Item
         key="1"
         className="child-header-menu-item"
-        onClick={childRedirect}
+        onClick={dashboard}
         icon={<HomeOutlined className="child-header-menu-item" />}
       >
         Home


### PR DESCRIPTION
User Story (Parent): 
- “As a parent, I would like for my kids to be directed back to the Child’s Dashboard when they click on "Home" instead of the Parent's Dashboard once they have Accepted a Mission.”

Motivation: 
- During a stakeholder meeting on 12/7/21, the co-founder of Scribble Stadium expressed the rationale behind why kids should not have the ability to access the parent’s dashboard once they have accepted a mission.

Before and After Changes: 
- Before the current changes were made, a child who has accepted a mission had the ability to click on the dropdown menu located at the left side of the header and click on Home which rerouted them back to the parent’s dashboard.

- After confirming the feature of preventing kids from accessing the parent’s dashboard with the stakeholders, it was agreed upon by the Front End team and approved by the Product Manager that the most efficient solution would be to simply route the Home link in the Header dropdown menu back to the Child’s Dashboard. 

- I went into src/components/common/Header.js and changed the onClick event under the Home item in the header’s dropdown menu to route back to the Child’s Dashboard instead of going to the Parent’s Dashboard.

## Type of Change:
[ x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] My code has been reviewed by at least one peer
- [ x  ] I have commented on my code, particularly in hard-to-understand areas
- [ x ] My changes generate no new warnings
- [ x ] There are no merge conflicts


![home](https://user-images.githubusercontent.com/54951984/145440301-5dddcb0a-46a9-4c09-a4b2-a545a5924cdf.png)
![childDashboard](https://user-images.githubusercontent.com/54951984/145440341-c8d687cd-a041-4f06-946f-29a7a5a76c8b.png)

