### PR TITLE
Changed button text gameplay mission  model for "read, draw, write"

### DIFF
--- a/src/components/pages/GamePlay/GameDrawStep.js
+++ b/src/components/pages/GamePlay/GameDrawStep.js
@@ -43,7 +43,7 @@ export default function GameDrawStep(props) {
           title: 'Scribble a side quest!',
           description:
             'Grab your favorite pencil and some loose leaf sheets of paper. Based on the prompt at the end of the reading, scribble down a side quest by hand. When your story is complete, snap a photo of your pages and upload them.',
-          buttonTxt: "Let's Go!",
+          buttonTxt: 'Battle!',
         };
 
         props.enableModalWindow(modalData);
@@ -67,7 +67,7 @@ export default function GameDrawStep(props) {
         title: 'Scribble a side quest!',
         description:
           'Grab your favorite pencil and some loose leaf sheets of paper. Based on the prompt at the end of the reading, scribble down a side quest by hand. When your story is complete, snap a photo of your pages and upload them.',
-        buttonTxt: "Let's Go!",
+        buttonTxt: 'Battle!',
       };
 
       props.enableModalWindow(modalData);

--- a/src/components/pages/GamePlay/GameMissionProgress.js
+++ b/src/components/pages/GamePlay/GameMissionProgress.js
@@ -22,7 +22,7 @@ export default function GameMissionProgress(props) {
       history.push(`${baseURL}/${step}`);
     } else {
       const modalData = {
-        title: 'YOu must read before advancing!',
+        title: 'You must read before advancing!',
         description: 'In order to complete the mission, reading is a MUST!',
         buttonTxt: 'Close',
       };

--- a/src/components/pages/GamePlay/GamePlayMain.js
+++ b/src/components/pages/GamePlay/GamePlayMain.js
@@ -99,7 +99,7 @@ const GamemodeBtns = props => {
     const data = {
       title: 'Welcome to Scribble Stadium!',
       description: ' Accept the mission to start your adventure!',
-      buttonTxt: "Let's Go!",
+      buttonTxt: 'Battle!',
     };
 
     props.enableModalWindow(data);

--- a/src/components/pages/GamePlay/GameReadStep.js
+++ b/src/components/pages/GamePlay/GameReadStep.js
@@ -17,7 +17,7 @@ export default function GameReadStep(props) {
         title: 'Your time to shine!',
         description:
           "Grab a sheet of paper and your drawing supplies. Based on the reading, draw your favorite scene by hand. When you're finished, snap a photo and upload your masterpiece.",
-        buttonTxt: "Let's Go!",
+        buttonTxt: 'Battle!',
       };
 
       props.enableModalWindow(modalData);

--- a/src/components/pages/GamePlay/GameWriteStep.js
+++ b/src/components/pages/GamePlay/GameWriteStep.js
@@ -42,7 +42,7 @@ export default function GameWriteStep(props) {
         title: 'Get ready for the boss battle!',
         description:
           'To complete this mission, your work will be put up head-to-head against a boss. If you are ready to fight, submit your work!',
-        buttonTxt: "Let's Go!",
+        buttonTxt: 'Battle!',
       };
 
       props.enableModalWindow(modalData);
@@ -74,7 +74,7 @@ export default function GameWriteStep(props) {
         title: 'Get ready for the boss battle!',
         description:
           'To complete this mission, your work will be put up head-to-head against a boss. If you are ready to fight, submit your work!',
-        buttonTxt: "Let's Go!",
+        buttonTxt: 'Battle!',
       };
 
       props.enableModalWindow(modalData);


### PR DESCRIPTION
# Description 
We changed the button between gameplay modes to say "Battle!" instead of "Let's go!". 
Fixes #

- What work was done? changed the text of a display button
- Why was this work done? create more engaged language for the user 
- What feature / user story is it for?- Gameplay Mission Draw, Read, & Write
- Any relevant links or images / screenshots n/a

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## Change Status

- [ ] Complete, tested, ready to review and merge


## Has This Been Tested

- [ ] Yes


## Checklist

- [ x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] My code has been reviewed by at least one peer
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ xx] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ x] There are no merge conflicts
https://www.loom.com/share/2bfad425f4704fb79b5668f541e2d961