### PR TITLE
bug/surrounding-elements-should-not-be-highlighted-on-arrow-clicks

### DIFF
--- a/src/components/pages/PointShare/RenderPointShare.js
+++ b/src/components/pages/PointShare/RenderPointShare.js
@@ -246,9 +246,7 @@ const PointShare = props => {
             <div className="counter-box">
               <p className="points-assigned">{storyOnePoints}</p>
               <div className="increment-box">
-                <CaretUpOutlined
-                  className="increment-up"
-                  style={{ color: '#6CEAE6', fontSize: '30px' }}
+                <Button
                   onClick={() => {
                     handlePointShare({
                       value: storyOnePoints + 5,
@@ -258,10 +256,19 @@ const PointShare = props => {
                       c: illustrationTwoPoints,
                     });
                   }}
-                />
-                <CaretDownOutlined
-                  className="increment-down"
-                  style={{ color: '#6CEAE6', fontSize: '30px' }}
+                  style={{
+                    width: '100%',
+                    padding: '0',
+                    border: 'none',
+                    margin: '0',
+                    overflow: 'hidden',
+                  }}
+                >
+                  <CaretUpOutlined
+                    style={{ color: '#6CEAE6', fontSize: '30px' }}
+                  />
+                </Button>
+                <Button
                   onClick={() => {
                     handlePointShare({
                       value:
@@ -274,7 +281,19 @@ const PointShare = props => {
                       c: illustrationTwoPoints,
                     });
                   }}
-                />
+                  style={{
+                    width: '100%',
+                    padding: '0',
+                    border: 'none',
+                    margin: '0',
+                    overflow: 'hidden',
+                  }}
+                >
+                  <CaretDownOutlined
+                    className="increment-down"
+                    style={{ color: '#6CEAE6', fontSize: '30px' }}
+                  />
+                </Button>
               </div>
             </div>
           </div>
@@ -293,9 +312,7 @@ const PointShare = props => {
             <div className="counter-box">
               <p className="points-assigned">{illustrationOnePoints}</p>
               <div className="increment-box">
-                <CaretUpOutlined
-                  className="increment-up"
-                  style={{ color: '#6CEAE6', fontSize: '30px' }}
+                <Button
                   onClick={() => {
                     handlePointShare({
                       value: illustrationOnePoints + 5,
@@ -305,10 +322,20 @@ const PointShare = props => {
                       c: illustrationTwoPoints,
                     });
                   }}
-                />
-                <CaretDownOutlined
-                  className="increment-down"
-                  style={{ color: '#6CEAE6', fontSize: '30px' }}
+                  style={{
+                    width: '100%',
+                    padding: '0',
+                    border: 'none',
+                    margin: '0',
+                    overflow: 'hidden',
+                  }}
+                >
+                  <CaretUpOutlined
+                    className="increment-up"
+                    style={{ color: '#6CEAE6', fontSize: '30px' }}
+                  />
+                </Button>
+                <Button
                   onClick={() => {
                     handlePointShare({
                       value:
@@ -321,7 +348,19 @@ const PointShare = props => {
                       c: illustrationTwoPoints,
                     });
                   }}
-                />
+                  style={{
+                    width: '100%',
+                    padding: '0',
+                    border: 'none',
+                    margin: '0',
+                    overflow: 'hidden',
+                  }}
+                >
+                  <CaretDownOutlined
+                    className="increment-down"
+                    style={{ color: '#6CEAE6', fontSize: '30px' }}
+                  />
+                </Button>
               </div>
             </div>
           </div>
@@ -352,9 +391,7 @@ const PointShare = props => {
             <div className="counter-box">
               <p className="points-assigned">{storyTwoPoints}</p>
               <div className="increment-box">
-                <CaretUpOutlined
-                  className="increment-up"
-                  style={{ color: '#6CEAE6', fontSize: '30px' }}
+                <Button
                   onClick={() => {
                     handlePointShare({
                       value: storyTwoPoints + 5,
@@ -364,10 +401,20 @@ const PointShare = props => {
                       c: illustrationTwoPoints,
                     });
                   }}
-                />
-                <CaretDownOutlined
-                  className="increment-down"
-                  style={{ color: '#6CEAE6', fontSize: '30px' }}
+                  style={{
+                    width: '100%',
+                    padding: '0',
+                    border: 'none',
+                    margin: '0',
+                    overflow: 'hidden',
+                  }}
+                >
+                  <CaretUpOutlined
+                    className="increment-up"
+                    style={{ color: '#6CEAE6', fontSize: '30px' }}
+                  />
+                </Button>
+                <Button
                   onClick={() => {
                     handlePointShare({
                       value:
@@ -380,7 +427,19 @@ const PointShare = props => {
                       c: illustrationTwoPoints,
                     });
                   }}
-                />
+                  style={{
+                    width: '100%',
+                    padding: '0',
+                    border: 'none',
+                    margin: '0',
+                    overflow: 'hidden',
+                  }}
+                >
+                  <CaretDownOutlined
+                    className="increment-down"
+                    style={{ color: '#6CEAE6', fontSize: '30px' }}
+                  />
+                </Button>
               </div>
             </div>
           </div>
@@ -405,9 +464,7 @@ const PointShare = props => {
               <div className="counter-box">
                 <p className="points-assigned">{illustrationTwoPoints}</p>
                 <div className="increment-box">
-                  <CaretUpOutlined
-                    className="increment-up"
-                    style={{ color: '#6CEAE6', fontSize: '30px' }}
+                  <Button
                     onClick={() => {
                       handlePointShare({
                         value: illustrationTwoPoints + 5,
@@ -417,10 +474,20 @@ const PointShare = props => {
                         c: storyOnePoints,
                       });
                     }}
-                  />
-                  <CaretDownOutlined
-                    className="increment-down"
-                    style={{ color: '#6CEAE6', fontSize: '30px' }}
+                    style={{
+                      width: '100%',
+                      padding: '0',
+                      border: 'none',
+                      margin: '0',
+                      overflow: 'hidden',
+                    }}
+                  >
+                    <CaretUpOutlined
+                      className="increment-up"
+                      style={{ color: '#6CEAE6', fontSize: '30px' }}
+                    />
+                  </Button>
+                  <Button
                     onClick={() => {
                       handlePointShare({
                         value:
@@ -433,7 +500,19 @@ const PointShare = props => {
                         c: storyOnePoints,
                       });
                     }}
-                  />
+                    style={{
+                      width: '100%',
+                      padding: '0',
+                      border: 'none',
+                      margin: '0',
+                      overflow: 'hidden',
+                    }}
+                  >
+                    <CaretDownOutlined
+                      className="increment-down"
+                      style={{ color: '#6CEAE6', fontSize: '30px' }}
+                    />
+                  </Button>
                 </div>
               </div>
             </div>

--- a/src/styles/less/PointShare.less
+++ b/src/styles/less/PointShare.less
@@ -139,5 +139,7 @@
 .increment-box {
   display: flex;
   flex-direction: column;
+  justify-content: center;
   margin-right: 10px;
+  overflow: hidden;
 }


### PR DESCRIPTION
# Description

Fixes #

- What work was done?

Wrapped up/down arrow icons with antd Button so that double-click won't trigger a highlight


- Why was this work done?

When clicking the up/down arrow on Point-Share, as they are not buttons, clicking too quickly would trigger a double-clicking and cause neighboring elements to be highlighted.

- What feature / user story is it for?



- Any relevant links or images / screenshots

Screenshot of behavior before the fix: 

![image](https://user-images.githubusercontent.com/13175016/145877388-be988885-789c-4fc3-a5f9-963b423be276.png)

Screenshot after the fix:

No elements are highlighted after multiple fast clicks.

![image](https://user-images.githubusercontent.com/13175016/145888471-eef166cd-79c2-4ab5-b28c-ba91db9a5d69.png)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested

- [x] Yes
- [ ] No
- [ ] Not necessary

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts

Trello Link:
https://trello.com/c/n3OEqTR2/777-bug-on-point-share-while-using-the-up-down-arrows-to-allocate-points-elements-get-highlighted


https://www.loom.com/share/24aeb266dfd84bf5a30289ada555a574