### PR TITLE
Set state so that when the user is done reading, the Heads up Display changes to Draw. After the user is done drawing, it changes to Write.

### DIFF
--- a/src/components/pages/Gallery/GalleryContainer.js
+++ b/src/components/pages/Gallery/GalleryContainer.js
@@ -6,6 +6,7 @@ import ChildFooter from '../../common/ChildFooter';
 import { Button } from 'antd';
 import { getChildByID } from '../../../api/index';
 import { setWeeklySubmissions } from '../../../state/actions/galleryActions';
+
 import WeeklySubmissions from './WeeklySubmissions';
 import { useHistory, useParams } from 'react-router-dom';
 

--- a/src/components/pages/GamePlay/GamePlayMission.js
+++ b/src/components/pages/GamePlay/GamePlayMission.js
@@ -3,6 +3,9 @@ import React, { useEffect, useState } from 'react';
 import { Route, Switch, useHistory } from 'react-router-dom';
 import { gsap } from 'gsap';
 import { ScrollToPlugin } from 'gsap/ScrollToPlugin';
+import { connect } from 'react-redux';
+
+import { setCurrActivity } from '../../../state/actions/currentActivityActions';
 
 //** Import Components */
 import GameMissionProgress from './GameMissionProgress';
@@ -11,7 +14,7 @@ import GameDrawStep from './GameDrawStep';
 import GameWriteStep from './GameWriteStep';
 import { MatchUp } from '../MatchUp/index';
 
-export default function GamePlayMission(props) {
+function GamePlayMission(props) {
   // GEt the history obj
   const history = useHistory();
 
@@ -56,7 +59,9 @@ export default function GamePlayMission(props) {
   const [modalClosed, setModalClosed] = useState(initialModalData);
 
   // Update the current step
+
   const updateCurStep = step => {
+    props.setCurrActivity(step);
     setCurrentStep(step);
     gsap.to(window, { duration: 1, scrollTo: '.hero' });
   };
@@ -163,3 +168,11 @@ export default function GamePlayMission(props) {
     </div>
   );
 }
+const mapStateToProps = state => {
+  return {
+    ...state,
+    currentActivity: state.currentActivity,
+  };
+};
+
+export default connect(mapStateToProps, { setCurrActivity })(GamePlayMission);

--- a/src/components/pages/HeadsUpDisplay/Hud.js
+++ b/src/components/pages/HeadsUpDisplay/Hud.js
@@ -3,9 +3,16 @@ import { CountDownTimer } from './CountdownTimer';
 import { DownCircleFilled } from '@ant-design/icons';
 import { Collapse } from 'antd';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
 function Hud(props) {
-  const { completedActivity, currentActivity, currentBar } = props;
+  const {
+    completedActivity,
+    currentActivity,
+    currentBar,
+    currActivity,
+  } = props;
+
   const activities = [
     'Read',
     'Draw',
@@ -47,6 +54,11 @@ function Hud(props) {
                 currentActivity !== a &&
                 completedActivity.length - 1 < activities.indexOf(a) &&
                 'restActive'
+              }
+              ${
+                currActivity.currActivity === a.toLowerCase()
+                  ? 'currentActivity'
+                  : ''
               }
               `}
             >
@@ -135,4 +147,11 @@ Hud.propTypes = {
   currentBar: PropTypes.string.isRequired,
 };
 
-export default Hud;
+const mapStateToProps = state => {
+  return {
+    ...state,
+    currentActivity: state.currentActivity,
+  };
+};
+
+export default connect(mapStateToProps)(Hud);

--- a/src/state/actions/currentActivityActions.js
+++ b/src/state/actions/currentActivityActions.js
@@ -1,0 +1,4 @@
+export const SET_CURRACTIVITY = 'SET_CURRACTIVITY';
+export const setCurrActivity = currActivity => dispatch => {
+  dispatch({ type: SET_CURRACTIVITY, payload: currActivity });
+};

--- a/src/state/actions/index.js
+++ b/src/state/actions/index.js
@@ -9,6 +9,7 @@ import * as date from './dateAction';
 import * as devMode from './devModeActions';
 import * as submissions from './galleryActions';
 import * as storiesNew from './newStories';
+import * as currActivity from './currentActivityActions';
 
 export {
   global,
@@ -22,4 +23,5 @@ export {
   devMode,
   submissions,
   storiesNew,
+  currActivity,
 };

--- a/src/state/reducers/currentActivityReducer.js
+++ b/src/state/reducers/currentActivityReducer.js
@@ -1,0 +1,14 @@
+import { currActivity } from '../actions';
+
+const initialState = {
+  currActivity: 'read',
+};
+
+export const reducer = (state = initialState, action) => {
+  switch (action.type) {
+    case currActivity.SET_CURRACTIVITY:
+      return { currActivity: action.payload };
+    default:
+      return state;
+  }
+};

--- a/src/state/reducers/index.js
+++ b/src/state/reducers/index.js
@@ -13,6 +13,7 @@ import { reducer as votes } from './votesReducer';
 import { reducer as date } from './dateReducer';
 import { reducer as devMode } from './devModeReducer';
 import { reducer as submissions } from './galleryReducer';
+import { reducer as currActivity } from './currentActivityReducer';
 
 const persistConfig = {
   key: 'root',
@@ -30,6 +31,7 @@ const rootReducer = combineReducers({
   date,
   devMode,
   submissions,
+  currActivity,
 });
 
 export default persistReducer(persistConfig, rootReducer);


### PR DESCRIPTION
Motivation:
- User Story (Child): "As a user, I would like to be able to see a display of my progress in the dashboard."

Before and After Changes:
- Before the changes were made, the `Squad Up` activity in the `Heads Up Display` was set as the initial state. The Heads Up Display also did not change states as the user completes an activity. For example, from `Read` to `Draw`, etc.
- After the changes I made, the initial state is now set to `Read`. Once the user is done reading, the `Heads Up Display` reflects the completed activity and changes to `Draw.` Once the user is done drawing, the `Heads Up Display` changes to `Write`.

Trello Card: https://trello.com/c/7O8sHIsh/792-update-and-display-childs-progress-in-headsup-using-timestamp

Before and After Images:
**BEFORE**
![HUDbefore](https://user-images.githubusercontent.com/54951984/146692426-270b173f-901e-4a7d-8fe5-6be8897d3b4a.png)
**AFTER**
![AfterHUD](https://user-images.githubusercontent.com/54951984/146702452-3d7e9e5d-9a8a-4d06-9027-79c94999d134.png)

**Loom Video:** https://www.loom.com/share/cfb366187a8b4b2296cc10e656cbcf82

## Type of change
- [x] New feature (non-breaking change which adds functionality)


## Change Status
- [x] Complete, tested, ready to review, and merge.


## Has This Been Tested
- [x] Yes


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
