### PR TITLE
Added media queries to make the shaded modal pop up more responsive on smaller screens on GamePlay.

### DIFF
--- a/src/styles/less/GamemodeStyles.less
+++ b/src/styles/less/GamemodeStyles.less
@@ -374,7 +374,8 @@
   /* notification-modal */
   #notification-modal {
     position: fixed;
-    width: 100vw;
+    width: 100%;
+    max-width: 100%;
     height: 100vh;
     background: rgba(0, 0, 0, 0.5);
     top: 0;
@@ -390,7 +391,10 @@
       background: url(../../assets/images/gamemodeimg/modal.png);
       background-size: cover;
       width: 720px;
+      max-width: 100%;
       height: 520px;
+      margin-left: auto;
+      margin-right: auto;
       transform: translateY(-100vh);
 
       .modal-content {

--- a/src/styles/less/GamemodeStyles.less
+++ b/src/styles/less/GamemodeStyles.less
@@ -397,6 +397,14 @@
       margin-right: auto;
       transform: translateY(-100vh);
 
+      @media @tablet {  
+        max-width: 80%;
+      }
+
+      @media @mobile {
+        max-width: 90%;
+      }
+
       .modal-content {
         padding: 20px 5%;
         display: flex;
@@ -409,11 +417,19 @@
         h3 {
           font-size: 3rem;
           text-transform: uppercase;
+
+          @media @mobile {
+            font-size: 2.5rem;
+          }
         }
 
         p {
           font-size: 1.5rem;
           line-height: 1.5em;
+
+          @media @mobile {
+            margin-left: .5rem;
+          }
         }
 
         button {


### PR DESCRIPTION
# Description

Fixes #

**- What work was done?**

We added media queries to the modal container to accommodate smaller screen sizes.

**- Why was this work done?**
To provide a better user experience for users on smaller devices.

**- What feature / user story is it for?**
https://trello.com/c/ee4d9i1Z

**- Any relevant links or images / screenshots**

**Before =** 
<img width="486" alt="shaded_bg_modal_iphone_x" src="https://user-images.githubusercontent.com/53699389/146846735-0a142e19-6c76-49ca-962c-cdcc6cf034df.png">

**After =**
<img width="630" alt="Screen Shot 2021-12-20 at 6 36 44 PM" src="https://user-images.githubusercontent.com/53699389/146846673-6258235d-7462-402f-abf0-b2586db103f1.png">


**## Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**## Change Status**

- [x] Complete, tested, ready to review, and merge


**## Has This Been Tested**

- [x] Yes

**## Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
https://www.loom.com/share/e9ba71735000499daac94a93b60f44c9