### PR TITLE
Bug/uploaded picture in draw page not retained in state

### DIFF
--- a/src/components/common/UploadDocs.js
+++ b/src/components/common/UploadDocs.js
@@ -18,6 +18,7 @@ export const UploadDocs = ({
   listType,
   handleChangeExtra,
   savedFileList,
+  handleRemove,
 }) => {
   const { user } = useAuth0();
 
@@ -108,6 +109,9 @@ export const UploadDocs = ({
       newFileList.splice(index, 1);
       return newFileList;
     });
+    if (handleRemove) {
+      handleRemove(file);
+    }
   };
 
   useEffect(() => {

--- a/src/components/pages/GamePlay/GameDrawStep.js
+++ b/src/components/pages/GamePlay/GameDrawStep.js
@@ -50,7 +50,6 @@ export default function GameDrawStep(props) {
         props.updateModalStatus('draw', true);
       }
 
-      // props.updateFileSubmissionData('drawings', []);
       history.push(`${props.baseURL}/write`);
     }, triggerSubmitTimer);
   };

--- a/src/components/pages/GamePlay/GameDrawStep.js
+++ b/src/components/pages/GamePlay/GameDrawStep.js
@@ -50,9 +50,15 @@ export default function GameDrawStep(props) {
         props.updateModalStatus('draw', true);
       }
 
-      props.updateFileSubmissionData('drawings', []);
+      // props.updateFileSubmissionData('drawings', []);
       history.push(`${props.baseURL}/write`);
     }, triggerSubmitTimer);
+  };
+
+  const handleRemove = file => {
+    const updatedList = fileList.filter(f => file.uid !== f.uid);
+    setFileList(updatedList);
+    props.updateFileSubmissionData('drawings', updatedList);
   };
 
   // This handles when we skip the drawing phase
@@ -126,6 +132,7 @@ export default function GameDrawStep(props) {
               handleSubmit={handleSubmit}
               alternateHandleSubmission={true}
               savedFileList={fileList}
+              handleRemove={handleRemove}
             />
 
             {fileList.length > 0 && (


### PR DESCRIPTION
# Description

When the user uploads the picture of the drawing. They go to the draw page and then go back. The uploaded picture is gone.

This is because the uploaded picture is not retained in the React state. The remove button of the uploaded picture is also not causing any changes to the parent state, and the removal of an upload is not reflected.

Fixes #

- What work was done?

> - Removed unnecessary reinitialization of uploaded file state
> - Added handleRemove to props of the UploadDocs component. It will be invoked inside of onRemove. 
> - Implemented handleRemove in the GameDrawStep component and passed into UploadDocs. handleRemove will then update the parent state

- Why was this work done?

> - uploaded files should be retained in state across the pages

- What feature / user story is it for?

> - https://trello.com/c/1u18LtdT/817-when-the-user-uploads-the-picture-of-the-drawing-they-go-to-draw-page-and-then-go-back-the-uploaded-picture-is-gone

- Any relevant links or images / screenshots

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [ ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested

- [x] Yes
- [ ] No
- [ ] Not necessary

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts


https://www.loom.com/share/fecb0dca30a54ac588d474950c304381