### PR TITLE
Feature/Mission button changes according to submission state

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -567,10 +567,15 @@ const reset = async () => {
   return apiAuthPut(`/reset/reset/`, null);
 };
 
+/**
+ *
+ * @param {Object} authState necessary for API functionality
+ * @param {number} childId id of the child who is "teaming up"
+ * @returns {Array} containing information on each submission for the child
+ */
 const getSubmissions = childId => {
   try {
     return apiAuthGet(`/child/${childId}/submissions`).then(response => {
-      console.log(response);
       return response.data;
     });
   } catch (error) {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -11,16 +11,16 @@ import { store } from '../state/index';
 function getApiUrl() {
   // on function call, grabs current redux state to check devMode status
   const state = store.getState();
-  const devMode = state.devMode.isDevModeActive;
+  // const devMode = state.devMode.isDevModeActive;
   let apiUrl = process.env.REACT_APP_API_URI;
   /**
    * apiUrl variable was initialized under the impression that REACT_APP_API_URI=localDB in 'development' and is productionDB in 'production'
    * If this is not the case in the future, this logic will need to change slightly.
    */
-  if (devMode && process.env.NODE_ENV === 'production') {
-    // if env = production and devMode active, use dev/staging DB, if env = production and devMode false, use production DB
-    apiUrl = process.env.REACT_APP_DS_API;
-  }
+  // if (devMode && process.env.NODE_ENV === 'production') {
+  //   // if env = production and devMode active, use dev/staging DB, if env = production and devMode false, use production DB
+  //   apiUrl = process.env.REACT_APP_DS_API;
+  // }
   // note that if environment is development then apiUrl should be the local db (not production or dev/staging DB)
   return apiUrl;
 }
@@ -567,6 +567,20 @@ const reset = async () => {
   return apiAuthPut(`/reset/reset/`, null);
 };
 
+const getSubmissions = childId => {
+  try {
+    return apiAuthGet(`/child/${childId}/submissions`).then(response => {
+      console.log(response);
+      return response.data;
+    });
+  } catch (error) {
+    return new Promise(() => {
+      console.log(error);
+      return [];
+    });
+  }
+};
+
 export {
   getApiUrl,
   sleep,
@@ -603,4 +617,5 @@ export {
   getGallerySubmissionsById,
   getGallery,
   reset,
+  getSubmissions,
 };

--- a/src/components/pages/ChildDashboard/RenderChildDashboard.js
+++ b/src/components/pages/ChildDashboard/RenderChildDashboard.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Header } from '../../common';
 import ChildFooter from '../../common/ChildFooter';
 import { Row, Col } from 'antd';
@@ -9,10 +9,20 @@ import { HUD } from '../HeadsUpDisplay/index';
 import Explosion from '../../../assets/images/gamemodeimg/explosion.png';
 import change_your_avatar from '../../../assets/images/child_dashboard_images/change_your_avatar.svg';
 import leaderboard_icon from '../../../assets/images/child_dashboard_images/leaderboard_icon.png';
+import { getSubmissions } from '../../../api/index';
 
 const RenderChildDashboard = props => {
   const { push } = useHistory();
   const [modalVisible, setModalVisible] = useState(false);
+  const [submissionData, setSubmissionData] = useState([]);
+
+  //Import api call to get submission and call here
+  useEffect(() => {
+    getSubmissions(1).then(res => {
+      setSubmissionData(res);
+      console.log(res);
+    });
+  }, []);
 
   const handleAcceptMission = e => {
     push('/gamemode');

--- a/src/components/pages/ChildDashboard/RenderChildDashboard.js
+++ b/src/components/pages/ChildDashboard/RenderChildDashboard.js
@@ -16,11 +16,11 @@ const RenderChildDashboard = props => {
   const [modalVisible, setModalVisible] = useState(false);
   const [submissionData, setSubmissionData] = useState([]);
 
-  //Import api call to get submission and call here
+  // ChildId hardcoded for now until global state of child is retrived
+  // Retrieves array of submissions pertaining to child id, response is in the form of an array
   useEffect(() => {
     getSubmissions(1).then(res => {
       setSubmissionData(res);
-      console.log(res);
     });
   }, []);
 
@@ -66,7 +66,11 @@ const RenderChildDashboard = props => {
             sm={12}
             onClick={handleAcceptMission}
           >
-            <p className="accept-mission-text">ACCEPT THE MISSION!</p>
+            {submissionData.length > 0 ? (
+              <p className="accept-mission-text">RESUME THE MISSION!</p>
+            ) : (
+              <p className="accept-mission-text">ACCEPT THE MISSION!</p>
+            )}
           </Col>
           <Col
             className="change-avatar"


### PR DESCRIPTION
# Description
Previously, the button to begin gameplay statically read "Accept the Mission". A getSubmissions API call was created to retrieve child submissions by the childId. This API was then used in the child dashboard to check whether or not child has any submissions. If they do, the button will read "Resume Mission", if not, "Accept the Mission"

Things to note:
-ChildId is currently being hardcoded due to the child not being persisted in state (this is a feature that is currently being worked on)
-getApiUrl() is a function that is being used for all API calls, but includes legacy code that is no longer relevant. The code is commented out for now, and will be removed in a separate PR


- What work was done?
- getSubmissions API call was created and used in RenderChildDashboard which retrieves all child submissions based on the id of the child and displays a different button
- Why was this work done?
- This work was done in order to make sure the button reads accordingly depending on where the child is in the game. 

- What feature / user story is it for?
- https://trello.com/c/zln3sIKe/864-as-a-player-i-want-the-button-on-the-gameplay-page-to-read-resume-instead-of-start-when-i-am-currently-working-on-the-submission

#Loom Video
https://www.loom.com/share/c725fce5a6e54d6ea7ae316dca4a3216

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Change Status
- [X] Complete, but not tested (may need new tests)

## Has This Been Tested

- [X] Yes, locally
- [ ] No
- [ ] Not necessary

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts
