### PR TITLE
Feature/resume mission button

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -567,10 +567,15 @@ const reset = async () => {
   return apiAuthPut(`/reset/reset/`, null);
 };
 
+/**
+ *
+ * @param {Object} authState necessary for API functionality
+ * @param {number} childId id of the child who is "teaming up"
+ * @returns {Array} containing information on each submission for the child
+ */
 const getSubmissions = childId => {
   try {
     return apiAuthGet(`/child/${childId}/submissions`).then(response => {
-      console.log(response);
       return response.data;
     });
   } catch (error) {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -11,16 +11,16 @@ import { store } from '../state/index';
 function getApiUrl() {
   // on function call, grabs current redux state to check devMode status
   const state = store.getState();
-  const devMode = state.devMode.isDevModeActive;
+  // const devMode = state.devMode.isDevModeActive;
   let apiUrl = process.env.REACT_APP_API_URI;
   /**
    * apiUrl variable was initialized under the impression that REACT_APP_API_URI=localDB in 'development' and is productionDB in 'production'
    * If this is not the case in the future, this logic will need to change slightly.
    */
-  if (devMode && process.env.NODE_ENV === 'production') {
-    // if env = production and devMode active, use dev/staging DB, if env = production and devMode false, use production DB
-    apiUrl = process.env.REACT_APP_DS_API;
-  }
+  // if (devMode && process.env.NODE_ENV === 'production') {
+  //   // if env = production and devMode active, use dev/staging DB, if env = production and devMode false, use production DB
+  //   apiUrl = process.env.REACT_APP_DS_API;
+  // }
   // note that if environment is development then apiUrl should be the local db (not production or dev/staging DB)
   return apiUrl;
 }
@@ -567,6 +567,20 @@ const reset = async () => {
   return apiAuthPut(`/reset/reset/`, null);
 };
 
+const getSubmissions = childId => {
+  try {
+    return apiAuthGet(`/child/${childId}/submissions`).then(response => {
+      console.log(response);
+      return response.data;
+    });
+  } catch (error) {
+    return new Promise(() => {
+      console.log(error);
+      return [];
+    });
+  }
+};
+
 export {
   getApiUrl,
   sleep,
@@ -603,4 +617,5 @@ export {
   getGallerySubmissionsById,
   getGallery,
   reset,
+  getSubmissions,
 };

--- a/src/components/pages/ChildDashboard/RenderChildDashboard.js
+++ b/src/components/pages/ChildDashboard/RenderChildDashboard.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Header } from '../../common';
 import ChildFooter from '../../common/ChildFooter';
 import { Row, Col } from 'antd';
@@ -9,10 +9,20 @@ import { HUD } from '../HeadsUpDisplay/index';
 import Explosion from '../../../assets/images/gamemodeimg/explosion.png';
 import change_your_avatar from '../../../assets/images/child_dashboard_images/change_your_avatar.svg';
 import leaderboard_icon from '../../../assets/images/child_dashboard_images/leaderboard_icon.png';
+import { getSubmissions } from '../../../api/index';
 
 const RenderChildDashboard = props => {
   const { push } = useHistory();
   const [modalVisible, setModalVisible] = useState(false);
+  const [submissionData, setSubmissionData] = useState([]);
+
+  //Import api call to get submission and call here
+  useEffect(() => {
+    getSubmissions(1).then(res => {
+      setSubmissionData(res);
+      console.log(res);
+    });
+  }, []);
 
   const handleAcceptMission = e => {
     push('/gamemode');

--- a/src/components/pages/ChildDashboard/RenderChildDashboard.js
+++ b/src/components/pages/ChildDashboard/RenderChildDashboard.js
@@ -16,11 +16,11 @@ const RenderChildDashboard = props => {
   const [modalVisible, setModalVisible] = useState(false);
   const [submissionData, setSubmissionData] = useState([]);
 
-  //Import api call to get submission and call here
+  // ChildId hardcoded for now until global state of child is retrived
+  // Retrieves array of submissions pertaining to child id, response is in the form of an array
   useEffect(() => {
     getSubmissions(1).then(res => {
       setSubmissionData(res);
-      console.log(res);
     });
   }, []);
 
@@ -66,7 +66,11 @@ const RenderChildDashboard = props => {
             sm={12}
             onClick={handleAcceptMission}
           >
-            <p className="accept-mission-text">ACCEPT THE MISSION!</p>
+            {submissionData.length > 0 ? (
+              <p className="accept-mission-text">RESUME THE MISSION!</p>
+            ) : (
+              <p className="accept-mission-text">ACCEPT THE MISSION!</p>
+            )}
           </Col>
           <Col
             className="change-avatar"


### PR DESCRIPTION
# Description
Text on "Accept The Mission" button reads "Resume The Mission" if submissions are present

Fixes #

- What work was done?
  RenderChildDashboard component connected to Redux store to dispatch FETCH_DATA
  FETCH_DATA action fires axios request to existing endpoint
  Axios request response is mocked with axios-mock-adapter to allow conditional rendering of button text
  
- Why was this work done?
  On the child dashboard, they have the option to start. However, if they leave and return, the game looks as if it is going to start a new game

- What feature / user story is it for?
  As a player, I want the button on the gameplay(?) page to read "resume" instead of "start" when I am currently working on the submission.
  
- Any relevant links or images / screenshots
  

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [ ] Complete, but not tested (may need new tests)

## Has This Been Tested

- [ ] No

## Checklist

- [X ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
