### PR TITLE
form submits at only 100 points shared

### DIFF
--- a/src/components/pages/PointShare/RenderPointShare.js
+++ b/src/components/pages/PointShare/RenderPointShare.js
@@ -108,10 +108,11 @@ const PointShare = props => {
 
   const formSubmit = () => {
     // notification used to handle errors related to the user's share points submission.
-    if (totalPoints < 0) {
+    if (totalPoints > 0) {
       notification.error({
         message: 'You may only allocate 100 points!',
       });
+
       return;
     }
     setTeamPoints([
@@ -192,9 +193,20 @@ const PointShare = props => {
     setTotalPoints(Math.max(100 - (value + a + b + c), 0));
   };
 
-  const handleSubmitPoints = () => {
-    formSubmit(); // submit the form
-    history.push('/child/winner'); // this page routes to Winner page per Ash / Jake's Whimsical
+  // const handleSubmitPoints = () => {
+  //   formSubmit(); // submit the form
+  //   history.push('/child/winner'); // this page routes to Winner page per Ash / Jake's Whimsical
+  // };
+
+  const handleSubmitPoints = props => {
+    if (totalPoints > 0) {
+      notification.error({
+        message: 'You may only allocate 100 points!',
+      });
+    } else if (totalPoints == 0) {
+      formSubmit(props); // submit the form
+      history.push('/child/winner'); // this page routes to Winner page per Ash / Jake's Whimsical
+    }
   };
 
   return (


### PR DESCRIPTION
# Description
button submission works only at 100 shared points
else: notification: 'You may only allocate 100 points!'

Fixes #
- What work was done?
created an if else statement around `handleSubmitPoints`
change notifications to `totalPoints` 
introduce `props`

- Why was this work done?
points sharing system button now works only at 100 max
- What feature / user story is it for?
[/child/point-share](url)
- Any relevant links or images / screenshots

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change Status
- [x] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested
- [x] Yes


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
